### PR TITLE
feat(issue-29): Auto-close calendar picker after date selection

### DIFF
--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { InputHTMLAttributes, forwardRef } from 'react';
+import { InputHTMLAttributes, forwardRef, useCallback } from 'react';
 import { cn } from '@/utils/helpers';
 
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -27,12 +27,30 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       type = 'text',
       required,
       id,
+      onChange,
       ...props
     },
     ref
   ) => {
     const inputId = id || props.name;
     const helpText = helperText || hint;
+
+    // Handler to auto-close datetime picker after selection
+    const handleChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (onChange) {
+          onChange(e);
+        }
+        // Auto-close datetime picker after value selection
+        if ((type === 'datetime-local' || type === 'date' || type === 'time') && e.target.value) {
+          // Trigger blur to close the picker after a small delay
+          setTimeout(() => {
+            e.target.blur();
+          }, 100);
+        }
+      },
+      [onChange, type]
+    );
 
     const baseInputStyles = 'block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500';
     
@@ -61,6 +79,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             ref={ref}
             id={inputId}
             type={type}
+            onChange={handleChange}
             className={cn(
               error ? errorInputStyles : baseInputStyles,
               leftIcon && 'pl-10',


### PR DESCRIPTION
- Added onChange handler in Input component for datetime/date/time inputs
- Triggers blur event after value selection to close the picker
- Works for datetime-local, date, and time input types
- Resolves #29