### PR TITLE
Fix Issue #22: Add placeholder pages for footer navigation links

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function ContactPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
+      <div className="max-w-md w-full text-center">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+          Contact Us
+        </h1>
+        <p className="text-lg text-gray-600 dark:text-gray-400 mb-8">
+          This page is coming soon. In the meantime, you can reach us at support@football-eu.com
+        </p>
+        <Link
+          href="/"
+          className="inline-block px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors"
+        >
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/cookies/page.tsx
+++ b/src/app/cookies/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function CookiesPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
+      <div className="max-w-md w-full text-center">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+          Cookie Policy
+        </h1>
+        <p className="text-lg text-gray-600 dark:text-gray-400 mb-8">
+          This page is coming soon. We're documenting our cookie usage and policies.
+        </p>
+        <Link
+          href="/"
+          className="inline-block px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors"
+        >
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function FAQPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
+      <div className="max-w-md w-full text-center">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+          FAQ
+        </h1>
+        <p className="text-lg text-gray-600 dark:text-gray-400 mb-8">
+          This page is coming soon. We're compiling frequently asked questions to help you get started.
+        </p>
+        <Link
+          href="/"
+          className="inline-block px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors"
+        >
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function HelpPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
+      <div className="max-w-md w-full text-center">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+          Help Center
+        </h1>
+        <p className="text-lg text-gray-600 dark:text-gray-400 mb-8">
+          This page is coming soon. We're building a comprehensive help center to assist you.
+        </p>
+        <Link
+          href="/"
+          className="inline-block px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors"
+        >
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-it-works/page.tsx
+++ b/src/app/how-it-works/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function HowItWorksPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
+      <div className="max-w-md w-full text-center">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+          How It Works
+        </h1>
+        <p className="text-lg text-gray-600 dark:text-gray-400 mb-8">
+          This page is coming soon. We're working on creating helpful content to guide you through our platform.
+        </p>
+        <Link
+          href="/"
+          className="inline-block px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors"
+        >
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function PricingPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
+      <div className="max-w-md w-full text-center">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+          Pricing
+        </h1>
+        <p className="text-lg text-gray-600 dark:text-gray-400 mb-8">
+          This page is coming soon. We're finalizing our pricing plans and will have them available shortly.
+        </p>
+        <Link
+          href="/"
+          className="inline-block px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors"
+        >
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
+      <div className="max-w-md w-full text-center">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+          Privacy Policy
+        </h1>
+        <p className="text-lg text-gray-600 dark:text-gray-400 mb-8">
+          This page is coming soon. We take your privacy seriously and are preparing a comprehensive policy.
+        </p>
+        <Link
+          href="/"
+          className="inline-block px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors"
+        >
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
+      <div className="max-w-md w-full text-center">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+          Terms of Service
+        </h1>
+        <p className="text-lg text-gray-600 dark:text-gray-400 mb-8">
+          This page is coming soon. Our legal team is finalizing the terms of service.
+        </p>
+        <Link
+          href="/"
+          className="inline-block px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors"
+        >
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #22

## Problem
Footer navigation links were leading to 404 errors because pages didn't exist yet.

## Solution
Created placeholder 'Coming Soon' pages for all footer links:

### Platform Section:
-  /main/tournaments - Already exists
-  /main/clubs - Already exists  
-  /how-it-works - **New placeholder page**
-  /pricing - **New placeholder page**

### Support Section:
-  /help - **New placeholder page**
-  /contact - **New placeholder page**
-  /faq - **New placeholder page**

### Legal Section:
-  /terms - **New placeholder page**
-  /privacy - **New placeholder page**
-  /cookies - **New placeholder page**

## Page Features
Each placeholder page includes:
- Clear heading with page title
- 'Coming Soon' message explaining the page is under development
- Context-appropriate messaging (e.g., contact email for Contact page)
- 'Back to Home' button for easy navigation
- Consistent styling with dark mode support

## Testing
- [x] All footer links now navigate to valid pages
- [x] No more 404 errors
- [x] Pages display correctly in light and dark modes
- [x] 'Back to Home' button works correctly