### PR TITLE
Fix Issue #20: Remove account type from registration

### DIFF
--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -8,9 +8,8 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useTranslation } from 'react-i18next';
 import { AuthLayout } from '@/components/layout';
-import { Button, Input, Select, Alert } from '@/components/ui';
+import { Button, Input, Alert } from '@/components/ui';
 import { useAuthStore } from '@/store';
-import type { UserRole } from '@/types';
 
 const registerSchema = z.object({
   firstName: z.string().min(2, 'First name must be at least 2 characters'),
@@ -25,7 +24,6 @@ const registerSchema = z.object({
     .regex(/[^A-Za-z0-9]/, 'Password must contain at least one special character'),
   confirmPassword: z.string(),
   country: z.string().min(2, 'Country is required'),
-  role: z.enum(['PARTICIPANT', 'ORGANIZER'] as const) as z.ZodType<UserRole>,
   acceptTerms: z.boolean().refine((val) => val === true, {
     message: 'You must accept the terms and conditions',
   }),
@@ -49,9 +47,6 @@ export default function RegisterPage() {
     formState: { errors },
   } = useForm<RegisterFormData>({
     resolver: zodResolver(registerSchema),
-    defaultValues: {
-      role: 'PARTICIPANT' as UserRole,
-    },
   });
 
   const onSubmit = async (data: RegisterFormData) => {
@@ -66,7 +61,7 @@ export default function RegisterPage() {
         phone: data.phone,
         password: data.password,
         country: data.country,
-        role: data.role as 'ORGANIZER' | 'PARTICIPANT',
+        role: 'PARTICIPANT', // Default role, user can change it later in dashboard
       });
       
       if (success) {
@@ -87,11 +82,6 @@ export default function RegisterPage() {
       setIsLoading(false);
     }
   };
-
-  const roleOptions = [
-    { value: 'PARTICIPANT', label: t('auth.roleParticipant') },
-    { value: 'ORGANIZER', label: t('auth.roleOrganizer') },
-  ];
 
   return (
     <AuthLayout
@@ -141,13 +131,6 @@ export default function RegisterPage() {
           placeholder="Romania"
           error={errors.country?.message}
           {...register('country')}
-        />
-
-        <Select
-          label={t('auth.accountType')}
-          options={roleOptions}
-          error={errors.role?.message}
-          {...register('role')}
         />
 
         <Input


### PR DESCRIPTION
Fixes #20

## Changes
Simplified the registration process by removing the account type (role) selection field.

### Before
- Users had to choose between PARTICIPANT or ORGANIZER during registration
- Required decision before understanding the platform

### After
- All new users automatically assigned PARTICIPANT role
- Cleaner registration form
- Users can change their role later from dashboard (to be implemented)

## Technical Changes
- Removed ole field from registration schema
- Removed Select component from imports
- Set default role to PARTICIPANT in registration submission
- Removed oleOptions variable
- Updated TypeScript types accordingly

## Benefits
-  Faster registration process
-  Fewer decisions for new users
-  Cleaner UI
-  Users can explore before committing to a role
-  Maintains flexibility - role can be changed in dashboard

## Future Enhancement
Dashboard will include role switching functionality to allow users to:
- View current role
- Switch between PARTICIPANT and ORGANIZER
- See role-specific features