### PR TITLE
Fix Issue #22: Add placeholder pages for footer navigation links

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Contact Us - Worldwide Football',
+  description: 'Get in touch with the Worldwide Football team.',
+};
+
+export default function ContactPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex items-center justify-center px-4">
+      <div className="max-w-2xl w-full text-center">
+        <div className="mb-8">
+          <h1 className="text-4xl sm:text-5xl font-bold text-gray-900 dark:text-white mb-4">
+            Contact Us
+          </h1>
+          <div className="inline-block px-4 py-2 bg-indigo-100 dark:bg-indigo-900/30 rounded-full mb-6">
+            <p className="text-indigo-600 dark:text-indigo-400 font-semibold">Coming Soon</p>
+          </div>
+          <p className="text-lg text-gray-600 dark:text-gray-400 mb-8">
+            We're setting up our contact page with multiple ways to reach us including email, 
+            phone support, and a contact form. Check back soon for our contact details.
+          </p>
+        </div>
+        
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-indigo-600 text-white rounded-md hover:bg-indigo-500 transition-colors font-semibold"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/cookies/page.tsx
+++ b/src/app/cookies/page.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Cookie Policy - Worldwide Football',
+  description: 'Cookie policy for the Worldwide Football platform.',
+};
+
+export default function CookiesPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex items-center justify-center px-4">
+      <div className="max-w-2xl w-full text-center">
+        <div className="mb-8">
+          <h1 className="text-4xl sm:text-5xl font-bold text-gray-900 dark:text-white mb-4">
+            Cookie Policy
+          </h1>
+          <div className="inline-block px-4 py-2 bg-indigo-100 dark:bg-indigo-900/30 rounded-full mb-6">
+            <p className="text-indigo-600 dark:text-indigo-400 font-semibold">Coming Soon</p>
+          </div>
+          <p className="text-lg text-gray-600 dark:text-gray-400 mb-8">
+            Our cookie policy is being finalized. It will explain what cookies we use, 
+            why we use them, and how you can manage your cookie preferences.
+          </p>
+        </div>
+        
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-indigo-600 text-white rounded-md hover:bg-indigo-500 transition-colors font-semibold"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'FAQ - Worldwide Football',
+  description: 'Frequently asked questions about the Worldwide Football platform.',
+};
+
+export default function FAQPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex items-center justify-center px-4">
+      <div className="max-w-2xl w-full text-center">
+        <div className="mb-8">
+          <h1 className="text-4xl sm:text-5xl font-bold text-gray-900 dark:text-white mb-4">
+            Frequently Asked Questions
+          </h1>
+          <div className="inline-block px-4 py-2 bg-indigo-100 dark:bg-indigo-900/30 rounded-full mb-6">
+            <p className="text-indigo-600 dark:text-indigo-400 font-semibold">Coming Soon</p>
+          </div>
+          <p className="text-lg text-gray-600 dark:text-gray-400 mb-8">
+            We're compiling the most frequently asked questions and their answers. 
+            This page will help you quickly find solutions to common questions about our platform.
+          </p>
+        </div>
+        
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-indigo-600 text-white rounded-md hover:bg-indigo-500 transition-colors font-semibold"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Help Center - Worldwide Football',
+  description: 'Get help and support for using the Worldwide Football platform.',
+};
+
+export default function HelpPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex items-center justify-center px-4">
+      <div className="max-w-2xl w-full text-center">
+        <div className="mb-8">
+          <h1 className="text-4xl sm:text-5xl font-bold text-gray-900 dark:text-white mb-4">
+            Help Center
+          </h1>
+          <div className="inline-block px-4 py-2 bg-indigo-100 dark:bg-indigo-900/30 rounded-full mb-6">
+            <p className="text-indigo-600 dark:text-indigo-400 font-semibold">Coming Soon</p>
+          </div>
+          <p className="text-lg text-gray-600 dark:text-gray-400 mb-8">
+            Our comprehensive help center is under development. It will feature FAQs, tutorials, 
+            troubleshooting guides, and video walkthroughs to help you get the most out of our platform.
+          </p>
+        </div>
+        
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-indigo-600 text-white rounded-md hover:bg-indigo-500 transition-colors font-semibold"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-it-works/page.tsx
+++ b/src/app/how-it-works/page.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'How It Works - Worldwide Football',
+  description: 'Learn how our platform works for tournament organizers and participants.',
+};
+
+export default function HowItWorksPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex items-center justify-center px-4">
+      <div className="max-w-2xl w-full text-center">
+        <div className="mb-8">
+          <h1 className="text-4xl sm:text-5xl font-bold text-gray-900 dark:text-white mb-4">
+            How It Works
+          </h1>
+          <div className="inline-block px-4 py-2 bg-indigo-100 dark:bg-indigo-900/30 rounded-full mb-6">
+            <p className="text-indigo-600 dark:text-indigo-400 font-semibold">Coming Soon</p>
+          </div>
+          <p className="text-lg text-gray-600 dark:text-gray-400 mb-8">
+            We're working on a comprehensive guide to help you understand how our platform works.
+            This page will include step-by-step instructions for both tournament organizers and participants.
+          </p>
+        </div>
+        
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-indigo-600 text-white rounded-md hover:bg-indigo-500 transition-colors font-semibold"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Pricing - Worldwide Football',
+  description: 'View our pricing plans for tournament management and participation.',
+};
+
+export default function PricingPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex items-center justify-center px-4">
+      <div className="max-w-2xl w-full text-center">
+        <div className="mb-8">
+          <h1 className="text-4xl sm:text-5xl font-bold text-gray-900 dark:text-white mb-4">
+            Pricing
+          </h1>
+          <div className="inline-block px-4 py-2 bg-indigo-100 dark:bg-indigo-900/30 rounded-full mb-6">
+            <p className="text-indigo-600 dark:text-indigo-400 font-semibold">Coming Soon</p>
+          </div>
+          <p className="text-lg text-gray-600 dark:text-gray-400 mb-8">
+            We're finalizing our pricing plans to offer the best value for tournament organizers and clubs.
+            Stay tuned for competitive pricing options and flexible packages.
+          </p>
+        </div>
+        
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-indigo-600 text-white rounded-md hover:bg-indigo-500 transition-colors font-semibold"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy - Worldwide Football',
+  description: 'Privacy policy for the Worldwide Football platform.',
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex items-center justify-center px-4">
+      <div className="max-w-2xl w-full text-center">
+        <div className="mb-8">
+          <h1 className="text-4xl sm:text-5xl font-bold text-gray-900 dark:text-white mb-4">
+            Privacy Policy
+          </h1>
+          <div className="inline-block px-4 py-2 bg-indigo-100 dark:bg-indigo-900/30 rounded-full mb-6">
+            <p className="text-indigo-600 dark:text-indigo-400 font-semibold">Coming Soon</p>
+          </div>
+          <p className="text-lg text-gray-600 dark:text-gray-400 mb-8">
+            We take your privacy seriously. Our privacy policy is being prepared to explain 
+            how we collect, use, and protect your personal information.
+          </p>
+        </div>
+        
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-indigo-600 text-white rounded-md hover:bg-indigo-500 transition-colors font-semibold"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service - Worldwide Football',
+  description: 'Terms of service for using the Worldwide Football platform.',
+};
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex items-center justify-center px-4">
+      <div className="max-w-2xl w-full text-center">
+        <div className="mb-8">
+          <h1 className="text-4xl sm:text-5xl font-bold text-gray-900 dark:text-white mb-4">
+            Terms of Service
+          </h1>
+          <div className="inline-block px-4 py-2 bg-indigo-100 dark:bg-indigo-900/30 rounded-full mb-6">
+            <p className="text-indigo-600 dark:text-indigo-400 font-semibold">Coming Soon</p>
+          </div>
+          <p className="text-lg text-gray-600 dark:text-gray-400 mb-8">
+            Our legal team is finalizing the terms of service. This document will outline 
+            the rules and regulations for using the Worldwide Football platform.
+          </p>
+        </div>
+        
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-indigo-600 text-white rounded-md hover:bg-indigo-500 transition-colors font-semibold"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Fixes #22 - Footer navigation links were showing 404 errors

## Changes
Created 8 professional 'Coming Soon' placeholder pages for all footer navigation links:

### Platform Section
-  /how-it-works - Platform guide placeholder
-  /pricing - Pricing plans placeholder

### Support Section
-  /help - Help center placeholder
-  /contact - Contact page placeholder
-  /faq - FAQ placeholder

### Legal Section
-  /terms - Terms of service placeholder
-  /privacy - Privacy policy placeholder
-  /cookies - Cookie policy placeholder

## Features
-  Consistent dark mode support across all pages
-  Fully responsive design
-  'Back to Home' navigation on every page
-  Professional 'Coming Soon' messaging
-  Proper SEO metadata for each page
-  Accessible design with semantic HTML

## Testing
 All pages verified with Playwright
 No more 404 errors on footer links
 Dark mode tested and working
 Navigation tested on all pages
 Responsive design verified

## Previous Issue
The previous implementation (commit 737e82a) was on a feature branch that was never merged to main. This is a complete reimplementation with proper testing.

## Screenshots
All pages display:
- Clear page heading
- 'Coming Soon' badge
- Descriptive message about upcoming content
- Easy navigation back to homepage