### PR TITLE
fix(dashboard): payments and groups page age group support (#170)

### DIFF
--- a/src/app/dashboard/groups/page.tsx
+++ b/src/app/dashboard/groups/page.tsx
@@ -5,16 +5,20 @@ import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 import { DashboardLayout } from '@/components/layout';
 import { Card, CardHeader, CardTitle, CardContent, Button, Badge, Loading, Select } from '@/components/ui';
-import { tournamentService, groupService } from '@/services';
-import { Tournament, Group } from '@/types';
+import { tournamentService, groupService, registrationService } from '@/services';
+import { Tournament, Group, AgeGroup } from '@/types';
+import { useAuthStore } from '@/store';
 
 export default function GroupsPage() {
   const { t } = useTranslation();
+  const { user } = useAuthStore();
   const [loading, setLoading] = useState(true);
   const [tournaments, setTournaments] = useState<Tournament[]>([]);
   const [selectedTournament, setSelectedTournament] = useState<string | null>(null);
+  const [selectedAgeGroup, setSelectedAgeGroup] = useState<string | null>(null);
   const [groups, setGroups] = useState<Group[]>([]);
   const [loadingGroups, setLoadingGroups] = useState(false);
+  const isOrganizer = user?.role === 'ORGANIZER' || user?.role === 'ADMIN';
 
   useEffect(() => {
     fetchTournaments();
@@ -29,21 +33,80 @@ export default function GroupsPage() {
   const fetchTournaments = async () => {
     setLoading(true);
     try {
-      const response = await tournamentService.getMyTournaments();
-      const resData = response.data as any;
-      
-      let tournamentData: Tournament[] = [];
-      if (Array.isArray(resData)) {
-        tournamentData = resData;
-      } else if (resData?.data && Array.isArray(resData.data)) {
-        tournamentData = resData.data;
-      } else if (resData?.items && Array.isArray(resData.items)) {
-        tournamentData = resData.items;
+      const allTournaments: Tournament[] = [];
+      const seenIds = new Set<string>();
+
+      // Fetch organizer's tournaments
+      try {
+        const response = await tournamentService.getMyTournaments();
+        const resData = response.data as any;
+        
+        let tournamentData: Tournament[] = [];
+        if (Array.isArray(resData)) {
+          tournamentData = resData;
+        } else if (resData?.data && Array.isArray(resData.data)) {
+          tournamentData = resData.data;
+        } else if (resData?.items && Array.isArray(resData.items)) {
+          tournamentData = resData.items;
+        }
+        
+        tournamentData.forEach(t => {
+          if (!seenIds.has(t.id)) {
+            seenIds.add(t.id);
+            allTournaments.push(t);
+          }
+        });
+      } catch {
+        // Organizer tournaments might fail for participants, that's OK
       }
-      
-      setTournaments(tournamentData);
-      if (tournamentData.length > 0) {
-        setSelectedTournament(tournamentData[0].id);
+
+      // Also fetch tournaments from user's registrations
+      try {
+        const regResponse = await registrationService.getMyRegistrations();
+        const regData = regResponse.data as any;
+        
+        let registrations: any[] = [];
+        if (Array.isArray(regData)) {
+          registrations = regData;
+        } else if (regData?.data && Array.isArray(regData.data)) {
+          registrations = regData.data;
+        } else if (regData?.items && Array.isArray(regData.items)) {
+          registrations = regData.items;
+        }
+
+        // Extract unique tournaments from registrations
+        for (const reg of registrations) {
+          if (reg.tournament && !seenIds.has(reg.tournament.id)) {
+            seenIds.add(reg.tournament.id);
+            allTournaments.push(reg.tournament);
+          }
+        }
+
+        // For tournaments without ageGroups loaded, fetch full details
+        for (let i = 0; i < allTournaments.length; i++) {
+          if (!allTournaments[i].ageGroups || allTournaments[i].ageGroups!.length === 0) {
+            try {
+              const fullTournament = await tournamentService.getTournamentById(allTournaments[i].id);
+              if (fullTournament.data) {
+                allTournaments[i] = fullTournament.data;
+              }
+            } catch {
+              // Keep partial data
+            }
+          }
+        }
+      } catch {
+        // Registrations might not be available
+      }
+
+      setTournaments(allTournaments);
+      if (allTournaments.length > 0) {
+        setSelectedTournament(allTournaments[0].id);
+        // Auto-select first age group if available
+        const firstAgeGroups = allTournaments[0].ageGroups;
+        if (firstAgeGroups && firstAgeGroups.length > 0 && firstAgeGroups[0].id) {
+          setSelectedAgeGroup(firstAgeGroups[0].id);
+        }
       }
     } catch (error) {
       console.error('Failed to fetch tournaments:', error);
@@ -80,7 +143,11 @@ export default function GroupsPage() {
     if (!selectedTournament) return;
     
     try {
-      await groupService.executeDraw(selectedTournament, { numberOfGroups: 4 });
+      const selectedTournamentData = tournaments.find(t => t.id === selectedTournament);
+      const ageGroup = selectedTournamentData?.ageGroups?.find(ag => ag.id === selectedAgeGroup);
+      const numberOfGroups = ageGroup?.groupsCount || 4;
+      
+      await groupService.executeDraw(selectedTournament, { numberOfGroups });
       fetchGroups(selectedTournament);
     } catch (error) {
       console.error('Failed to execute draw:', error);
@@ -103,6 +170,21 @@ export default function GroupsPage() {
     value: t.id,
     label: t.name,
   }));
+
+  const selectedTournamentData = tournaments.find(t => t.id === selectedTournament);
+  const ageGroupOptions = (selectedTournamentData?.ageGroups || []).map(ag => ({
+    value: ag.id || '',
+    label: `${ag.displayLabel || ag.ageCategory || 'Category'} (Birth Year: ${ag.birthYear})`,
+  }));
+
+  const handleTournamentChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const tournamentId = e.target.value;
+    setSelectedTournament(tournamentId);
+    // Auto-select first age group of the new tournament
+    const tournament = tournaments.find(t => t.id === tournamentId);
+    const firstAgeGroup = tournament?.ageGroups?.[0];
+    setSelectedAgeGroup(firstAgeGroup?.id || null);
+  };
 
   if (loading) {
     return (
@@ -134,30 +216,44 @@ export default function GroupsPage() {
           <Card>
             <CardContent className="py-4">
               <div className="flex flex-col gap-4">
-                <div className="w-full sm:max-w-md">
-                  <Select
-                    label={t('groups.selectTournament', 'Select Tournament')}
-                    options={tournamentOptions}
-                    value={selectedTournament || ''}
-                    onChange={(e) => setSelectedTournament(e.target.value)}
-                  />
+                <div className="flex flex-col sm:flex-row gap-4">
+                  <div className="w-full sm:max-w-md">
+                    <Select
+                      label={t('groups.selectTournament', 'Select Tournament')}
+                      options={tournamentOptions}
+                      value={selectedTournament || ''}
+                      onChange={handleTournamentChange}
+                    />
+                  </div>
+                  {ageGroupOptions.length > 0 && (
+                    <div className="w-full sm:max-w-xs">
+                      <Select
+                        label={t('groups.selectAgeGroup', 'Age Group')}
+                        options={ageGroupOptions}
+                        value={selectedAgeGroup || ''}
+                        onChange={(e) => setSelectedAgeGroup(e.target.value)}
+                      />
+                    </div>
+                  )}
                 </div>
-                <div className="flex flex-col xs:flex-row gap-2">
-                  <Button
-                    variant="primary"
-                    onClick={handleExecuteDraw}
-                    disabled={!selectedTournament || loadingGroups}
-                  >
-                    {t('groups.executeDraw')}
-                  </Button>
-                  <Button
-                    variant="danger"
-                    onClick={handleResetDraw}
-                    disabled={!selectedTournament || groups.length === 0 || loadingGroups}
-                  >
-                    {t('groups.resetDraw')}
-                  </Button>
-                </div>
+                {isOrganizer && (
+                  <div className="flex flex-col xs:flex-row gap-2">
+                    <Button
+                      variant="primary"
+                      onClick={handleExecuteDraw}
+                      disabled={!selectedTournament || loadingGroups}
+                    >
+                      {t('groups.executeDraw')}
+                    </Button>
+                    <Button
+                      variant="danger"
+                      onClick={handleResetDraw}
+                      disabled={!selectedTournament || groups.length === 0 || loadingGroups}
+                    >
+                      {t('groups.resetDraw')}
+                    </Button>
+                  </div>
+                )}
               </div>
             </CardContent>
           </Card>
@@ -272,11 +368,16 @@ export default function GroupsPage() {
                 {t('groups.noGroups', 'No Groups Yet')}
               </h3>
               <p className="text-gray-500 mb-4">
-                {t('groups.noGroupsDesc', 'Execute a draw to create groups for this tournament')}
+                {isOrganizer 
+                  ? t('groups.noGroupsDesc', 'Execute a draw to create groups for this tournament')
+                  : t('groups.noGroupsParticipant', 'Groups have not been drawn yet for this tournament')
+                }
               </p>
-              <Button variant="primary" onClick={handleExecuteDraw}>
-                {t('groups.executeDraw')}
-              </Button>
+              {isOrganizer && (
+                <Button variant="primary" onClick={handleExecuteDraw}>
+                  {t('groups.executeDraw')}
+                </Button>
+              )}
             </CardContent>
           </Card>
         ) : null}

--- a/src/app/dashboard/payments/page.tsx
+++ b/src/app/dashboard/payments/page.tsx
@@ -109,15 +109,28 @@ export default function PaymentsPage() {
                         <Badge variant={getPaymentStatusBadge(registration.paymentStatus)}>
                           {registration.paymentStatus}
                         </Badge>
+                        {(registration as any).ageGroup?.displayLabel && (
+                          <Badge variant="info">
+                            {(registration as any).ageGroup.displayLabel}
+                          </Badge>
+                        )}
                       </div>
                       <div className="text-sm text-gray-500 space-y-1">
                         <p>Club: {registration.club?.name || 'N/A'}</p>
+                        <p>Team: {registration.team?.name || 'Not specified'}</p>
+                        {(registration as any).ageGroup?.ageCategory && (
+                          <p>Category: {(registration as any).ageGroup.ageCategory}</p>
+                        )}
                         <p>Registered: {formatDateTime(registration.createdAt)}</p>
                       </div>
                     </div>
                     <div className="text-right">
                       <p className="text-2xl font-bold text-gray-900">
-                        {formatCurrency(registration.tournament?.participationFee || 0)}
+                        {formatCurrency(
+                          (registration as any).ageGroup?.participationFee
+                            || registration.tournament?.participationFee
+                            || 0
+                        )}
                       </p>
                       <Link
                         href={`/dashboard/registrations/${registration.id}`}

--- a/src/app/dashboard/registrations/page.tsx
+++ b/src/app/dashboard/registrations/page.tsx
@@ -249,10 +249,10 @@ export default function RegistrationsPage() {
                             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
                             </svg>
-                            {registration.club?.name || registration.coachName || 'Club'}
-                            {registration.team?.name && (
-                              <span className="text-gray-400">• {registration.team.name}</span>
-                            )}
+                            Club: {registration.club?.name || registration.coachName || 'N/A'}
+                            <span className="text-gray-400">
+                              • Team: {registration.team?.name || 'Not specified'}
+                            </span>
                           </span>
                           <span className="flex items-center gap-1">
                             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
- Payments page: Add age group badge and category display, use age-group-level participation fee
- Groups page: Add participant access via registrations, add age group selector, role-based UI
- Registrations page: Add 'Club:' prefix for clarity

Fixes #170