### PR TITLE
feat(#87): Teams and Players frontend pages

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -345,9 +345,7 @@ export default function DashboardPage() {
                       >
                         <div>
                           <p className="font-medium">{registration.club?.name || 'Unknown Club'}</p>
-                          {registration.team?.name && (
-                            <p className="text-sm text-gray-600">{registration.team.name}</p>
-                          )}
+                          <p className="text-sm text-gray-600">Team: {registration.team?.name || 'Not specified'}</p>
                           <p className="text-sm text-gray-500">
                             {registration.tournament?.name || 'Unknown Tournament'}
                           </p>

--- a/src/app/dashboard/players/[id]/edit/page.tsx
+++ b/src/app/dashboard/players/[id]/edit/page.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import { DashboardLayout } from '@/components/layout';
+import { Card, CardHeader, CardTitle, CardContent, Button, Input, Alert, Loading } from '@/components/ui';
+import { playerService, teamService } from '@/services';
+import type { Player, Team } from '@/types';
+
+export default function EditPlayerPage() {
+  const { t } = useTranslation();
+  const params = useParams();
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
+
+  const [form, setForm] = useState({
+    firstname: '',
+    lastname: '',
+    dateOfBirth: '',
+  });
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [playerRes, teamsRes] = await Promise.all([
+          playerService.getPlayerById(params.id as string),
+          teamService.getAllTeams(),
+        ]);
+
+        const player = (playerRes as any)?.data ?? playerRes;
+        setForm({
+          firstname: player.firstname,
+          lastname: player.lastname,
+          dateOfBirth: player.dateOfBirth,
+        });
+        setSelectedTeamIds((player.teams || []).map((t: Team) => t.id));
+
+        const teamsData = (teamsRes as any)?.data ?? teamsRes;
+        setTeams(Array.isArray(teamsData) ? teamsData : (teamsData as any)?.data ?? []);
+      } catch {
+        setError('Failed to load player');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [params.id]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      await playerService.updatePlayer(params.id as string, {
+        ...form,
+        teamIds: selectedTeamIds,
+      });
+      router.push(`/dashboard/players/${params.id}`);
+    } catch (err: any) {
+      const msg = err?.response?.data?.error?.message || err?.message || 'Failed to update player';
+      setError(msg);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toggleTeam = (teamId: string) => {
+    setSelectedTeamIds((prev) =>
+      prev.includes(teamId) ? prev.filter((id) => id !== teamId) : [...prev, teamId]
+    );
+  };
+
+  if (loading) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center min-h-[400px]">
+          <Loading size="lg" />
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-2xl mx-auto space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Edit Player</h1>
+          <p className="text-gray-600 mt-1">Update player details and team assignments</p>
+        </div>
+
+        {error && <Alert variant="error">{error}</Alert>}
+
+        <form onSubmit={handleSubmit}>
+          <Card>
+            <CardHeader>
+              <CardTitle>Player Details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <Input
+                  label="First Name *"
+                  value={form.firstname}
+                  onChange={(e) => setForm({ ...form, firstname: e.target.value })}
+                  required
+                />
+                <Input
+                  label="Last Name *"
+                  value={form.lastname}
+                  onChange={(e) => setForm({ ...form, lastname: e.target.value })}
+                  required
+                />
+              </div>
+
+              <Input
+                type="date"
+                label="Date of Birth *"
+                value={form.dateOfBirth}
+                onChange={(e) => setForm({ ...form, dateOfBirth: e.target.value })}
+                required
+              />
+            </CardContent>
+          </Card>
+
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>Team Assignments</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {selectedTeamIds.length > 0 && (
+                <div className="flex flex-wrap gap-2 mb-4">
+                  {selectedTeamIds.map((id) => {
+                    const team = teams.find((t) => t.id === id);
+                    return (
+                      <span
+                        key={id}
+                        className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-primary/10 text-primary text-sm"
+                      >
+                        {team?.name || id}
+                        <button
+                          type="button"
+                          onClick={() => toggleTeam(id)}
+                          className="ml-1 text-primary/60 hover:text-primary"
+                        >
+                          &times;
+                        </button>
+                      </span>
+                    );
+                  })}
+                </div>
+              )}
+
+              {teams.length > 0 ? (
+                <div className="border rounded-lg divide-y max-h-60 overflow-y-auto">
+                  {teams.map((team) => (
+                    <label
+                      key={team.id}
+                      className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedTeamIds.includes(team.id)}
+                        onChange={() => toggleTeam(team.id)}
+                        className="rounded border-gray-300"
+                      />
+                      <div>
+                        <span className="text-sm font-medium text-gray-900">{team.name}</span>
+                        <span className="text-xs text-gray-500 ml-2">
+                          {team.ageCategory} &middot; {team.club?.name || ''}
+                        </span>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-gray-500">No teams available</p>
+              )}
+            </CardContent>
+          </Card>
+
+          <div className="flex justify-end gap-3 mt-6">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => router.push(`/dashboard/players/${params.id}`)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" isLoading={saving}>
+              Save Changes
+            </Button>
+          </div>
+        </form>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/dashboard/players/[id]/page.tsx
+++ b/src/app/dashboard/players/[id]/page.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+import { DashboardLayout } from '@/components/layout';
+import { Card, CardHeader, CardTitle, CardContent, Button, Badge, Alert, Loading } from '@/components/ui';
+import { playerService } from '@/services';
+import type { Player } from '@/types';
+
+export default function PlayerDetailPage() {
+  const { t } = useTranslation();
+  const params = useParams();
+  const router = useRouter();
+  const [player, setPlayer] = useState<Player | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchPlayer = async () => {
+      try {
+        const res = await playerService.getPlayerById(params.id as string);
+        const data = (res as any)?.data ?? res;
+        setPlayer(data);
+      } catch {
+        setError('Failed to load player');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchPlayer();
+  }, [params.id]);
+
+  const handleDelete = async () => {
+    if (!player || !confirm('Are you sure you want to delete this player?')) return;
+    try {
+      await playerService.deletePlayer(player.id);
+      router.push('/dashboard/players');
+    } catch {
+      setError('Failed to delete player');
+    }
+  };
+
+  const calculateAge = (dateOfBirth: string) => {
+    const birth = new Date(dateOfBirth);
+    const today = new Date();
+    let age = today.getFullYear() - birth.getFullYear();
+    const m = today.getMonth() - birth.getMonth();
+    if (m < 0 || (m === 0 && today.getDate() < birth.getDate())) age--;
+    return age;
+  };
+
+  if (loading) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center min-h-[400px]">
+          <Loading size="lg" />
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  if (!player) {
+    return (
+      <DashboardLayout>
+        <Alert variant="error">{error || 'Player not found'}</Alert>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        {error && <Alert variant="error">{error}</Alert>}
+
+        {/* Header */}
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center">
+              <span className="text-2xl font-bold text-primary">
+                {player.firstname.charAt(0)}{player.lastname.charAt(0)}
+              </span>
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">
+                {player.firstname} {player.lastname}
+              </h1>
+              <p className="text-gray-600 mt-1">
+                Age {calculateAge(player.dateOfBirth)} &middot; Born {new Date(player.dateOfBirth).toLocaleDateString()}
+              </p>
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Link href={`/dashboard/players/${player.id}/edit`}>
+              <Button variant="primary">
+                <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                </svg>
+                Edit
+              </Button>
+            </Link>
+            <Button
+              variant="ghost"
+              onClick={handleDelete}
+              className="text-red-600 hover:text-red-800"
+            >
+              <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+              Delete
+            </Button>
+          </div>
+        </div>
+
+        {/* Details */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Player Information</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <p className="text-sm text-gray-500">First Name</p>
+                <p className="font-medium">{player.firstname}</p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-500">Last Name</p>
+                <p className="font-medium">{player.lastname}</p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-500">Date of Birth</p>
+                <p className="font-medium">{new Date(player.dateOfBirth).toLocaleDateString()}</p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-500">Age</p>
+                <p className="font-medium">{calculateAge(player.dateOfBirth)} years</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Teams ({player.teams?.length || 0})</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {player.teams && player.teams.length > 0 ? (
+                <div className="space-y-3">
+                  {player.teams.map((team) => (
+                    <div key={team.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+                      <div>
+                        <Link href={`/dashboard/teams/${team.id}`} className="font-medium text-gray-900 hover:text-primary">
+                          {team.name}
+                        </Link>
+                        <p className="text-xs text-gray-500">{team.ageCategory} &middot; {team.club?.name || ''}</p>
+                      </div>
+                      <Badge variant="info">{team.ageCategory}</Badge>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-gray-500">Not assigned to any teams yet</p>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/dashboard/players/create/page.tsx
+++ b/src/app/dashboard/players/create/page.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import { DashboardLayout } from '@/components/layout';
+import { Card, CardHeader, CardTitle, CardContent, Button, Input, Alert } from '@/components/ui';
+import { playerService, teamService } from '@/services';
+import type { Team } from '@/types';
+
+export default function CreatePlayerPage() {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
+
+  const [form, setForm] = useState({
+    firstname: '',
+    lastname: '',
+    dateOfBirth: '',
+  });
+
+  useEffect(() => {
+    const fetchTeams = async () => {
+      try {
+        const res = await teamService.getAllTeams();
+        const data = (res as any)?.data ?? res;
+        setTeams(Array.isArray(data) ? data : (data as any)?.data ?? []);
+      } catch { /* silently fail */ }
+    };
+    fetchTeams();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.firstname || !form.lastname || !form.dateOfBirth) {
+      setError('Please fill in all required fields');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      await playerService.createPlayer({
+        ...form,
+        teamIds: selectedTeamIds.length > 0 ? selectedTeamIds : undefined,
+      });
+      router.push('/dashboard/players');
+    } catch (err: any) {
+      const msg = err?.response?.data?.error?.message || err?.message || 'Failed to create player';
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const toggleTeam = (teamId: string) => {
+    setSelectedTeamIds((prev) =>
+      prev.includes(teamId) ? prev.filter((id) => id !== teamId) : [...prev, teamId]
+    );
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-2xl mx-auto space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Add Player</h1>
+          <p className="text-gray-600 mt-1">Add a new player and assign to teams</p>
+        </div>
+
+        {error && <Alert variant="error">{error}</Alert>}
+
+        <form onSubmit={handleSubmit}>
+          <Card>
+            <CardHeader>
+              <CardTitle>Player Details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <Input
+                  label="First Name *"
+                  placeholder="e.g. Alex"
+                  value={form.firstname}
+                  onChange={(e) => setForm({ ...form, firstname: e.target.value })}
+                  required
+                />
+                <Input
+                  label="Last Name *"
+                  placeholder="e.g. Popescu"
+                  value={form.lastname}
+                  onChange={(e) => setForm({ ...form, lastname: e.target.value })}
+                  required
+                />
+              </div>
+
+              <Input
+                type="date"
+                label="Date of Birth *"
+                value={form.dateOfBirth}
+                onChange={(e) => setForm({ ...form, dateOfBirth: e.target.value })}
+                required
+              />
+            </CardContent>
+          </Card>
+
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>Assign to Teams</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {selectedTeamIds.length > 0 && (
+                <div className="flex flex-wrap gap-2 mb-4">
+                  {selectedTeamIds.map((id) => {
+                    const team = teams.find((t) => t.id === id);
+                    return (
+                      <span
+                        key={id}
+                        className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-primary/10 text-primary text-sm"
+                      >
+                        {team?.name || id}
+                        <button
+                          type="button"
+                          onClick={() => toggleTeam(id)}
+                          className="ml-1 text-primary/60 hover:text-primary"
+                        >
+                          &times;
+                        </button>
+                      </span>
+                    );
+                  })}
+                </div>
+              )}
+
+              {teams.length > 0 ? (
+                <div className="border rounded-lg divide-y max-h-60 overflow-y-auto">
+                  {teams.map((team) => (
+                    <label
+                      key={team.id}
+                      className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedTeamIds.includes(team.id)}
+                        onChange={() => toggleTeam(team.id)}
+                        className="rounded border-gray-300"
+                      />
+                      <div>
+                        <span className="text-sm font-medium text-gray-900">{team.name}</span>
+                        <span className="text-xs text-gray-500 ml-2">
+                          {team.ageCategory} &middot; {team.club?.name || ''}
+                        </span>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-gray-500">No teams available. Create a team first.</p>
+              )}
+            </CardContent>
+          </Card>
+
+          <div className="flex justify-end gap-3 mt-6">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => router.push('/dashboard/players')}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" isLoading={loading}>
+              Add Player
+            </Button>
+          </div>
+        </form>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/dashboard/players/page.tsx
+++ b/src/app/dashboard/players/page.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+import { DashboardLayout } from '@/components/layout';
+import { Card, CardContent, Button, Badge, Loading, Input, Alert } from '@/components/ui';
+import { playerService } from '@/services';
+import type { Player } from '@/types';
+
+export default function PlayersPage() {
+  const { t } = useTranslation();
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+
+  const fetchPlayers = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await playerService.getPlayers({
+        search: search || undefined,
+        pageSize: 50,
+      });
+      const data = (res as any)?.data ?? res;
+      setPlayers(Array.isArray(data) ? data : (data as any)?.data ?? []);
+    } catch (err: any) {
+      setError(err?.message || 'Failed to load players');
+    } finally {
+      setLoading(false);
+    }
+  }, [search]);
+
+  useEffect(() => {
+    fetchPlayers();
+  }, [fetchPlayers]);
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Are you sure you want to delete this player?')) return;
+    try {
+      await playerService.deletePlayer(id);
+      setPlayers((prev) => prev.filter((p) => p.id !== id));
+    } catch (err: any) {
+      setError(err?.message || 'Failed to delete player');
+    }
+  };
+
+  const calculateAge = (dateOfBirth: string) => {
+    const birth = new Date(dateOfBirth);
+    const today = new Date();
+    let age = today.getFullYear() - birth.getFullYear();
+    const m = today.getMonth() - birth.getMonth();
+    if (m < 0 || (m === 0 && today.getDate() < birth.getDate())) age--;
+    return age;
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <h1 className="text-xl sm:text-2xl font-bold text-gray-900">
+              {t('nav.players', 'Players')}
+            </h1>
+            <p className="text-sm sm:text-base text-gray-600 mt-1">
+              Manage players across your teams
+            </p>
+          </div>
+          <Link href="/dashboard/players/create" className="self-start sm:self-auto">
+            <Button variant="primary">
+              <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+              Add Player
+            </Button>
+          </Link>
+        </div>
+
+        {/* Search */}
+        <div className="flex-1 max-w-md">
+          <Input
+            placeholder="Search players by name..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+
+        {error && <Alert variant="error">{error}</Alert>}
+
+        {/* Content */}
+        {loading ? (
+          <div className="flex justify-center py-12">
+            <Loading size="lg" />
+          </div>
+        ) : players.length === 0 ? (
+          <Card>
+            <CardContent className="text-center py-12">
+              <svg className="w-16 h-16 mx-auto text-gray-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+              </svg>
+              <h3 className="text-lg font-medium text-gray-900 mb-2">No players yet</h3>
+              <p className="text-gray-500 mb-4">Add your first player to get started</p>
+              <Link href="/dashboard/players/create">
+                <Button variant="primary">Add First Player</Button>
+              </Link>
+            </CardContent>
+          </Card>
+        ) : (
+          <Card>
+            <CardContent className="p-0">
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Name
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Date of Birth
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Age
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Teams
+                      </th>
+                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Actions
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {players.map((player) => (
+                      <tr key={player.id} className="hover:bg-gray-50">
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <div className="flex items-center">
+                            <div className="w-8 h-8 bg-primary/10 rounded-full flex items-center justify-center mr-3">
+                              <span className="text-sm font-semibold text-primary">
+                                {player.firstname.charAt(0)}{player.lastname.charAt(0)}
+                              </span>
+                            </div>
+                            <div>
+                              <Link
+                                href={`/dashboard/players/${player.id}`}
+                                className="font-medium text-gray-900 hover:text-primary"
+                              >
+                                {player.firstname} {player.lastname}
+                              </Link>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                          {new Date(player.dateOfBirth).toLocaleDateString()}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                          {calculateAge(player.dateOfBirth)}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <div className="flex flex-wrap gap-1">
+                            {player.teams && player.teams.length > 0 ? (
+                              player.teams.map((team) => (
+                                <Badge key={team.id} variant="info">
+                                  {team.name}
+                                </Badge>
+                              ))
+                            ) : (
+                              <span className="text-sm text-gray-400">No teams</span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                          <div className="flex items-center justify-end gap-2">
+                            <Link href={`/dashboard/players/${player.id}/edit`}>
+                              <Button variant="outline" size="sm">
+                                Edit
+                              </Button>
+                            </Link>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleDelete(player.id)}
+                              className="text-red-600 hover:text-red-800"
+                            >
+                              Delete
+                            </Button>
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/dashboard/registrations/[id]/page.tsx
+++ b/src/app/dashboard/registrations/[id]/page.tsx
@@ -243,12 +243,10 @@ export default function RegistrationDetailPage() {
                   </Link>
                 </div>
               )}
-              {registration.team && (
-                <div>
-                  <p className="text-sm text-gray-500">Team</p>
-                  <p className="font-medium">{registration.team.name}</p>
-                </div>
-              )}
+              <div>
+                <p className="text-sm text-gray-500">Team</p>
+                <p className="font-medium">{registration.team?.name || 'Not specified'}</p>
+              </div>
               <div>
                 <p className="text-sm text-gray-500">Emergency Contact</p>
                 <p className="font-medium">{registration.emergencyContact || '-'}</p>

--- a/src/app/dashboard/teams/[id]/edit/page.tsx
+++ b/src/app/dashboard/teams/[id]/edit/page.tsx
@@ -1,0 +1,274 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import { DashboardLayout } from '@/components/layout';
+import { Card, CardHeader, CardTitle, CardContent, Button, Input, Alert, Loading } from '@/components/ui';
+import { teamService, clubService, playerService } from '@/services';
+import type { Club, Player } from '@/types';
+
+export default function EditTeamPage() {
+  const { t } = useTranslation();
+  const params = useParams();
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [clubs, setClubs] = useState<Club[]>([]);
+  const [availablePlayers, setAvailablePlayers] = useState<Player[]>([]);
+  const [currentPlayers, setCurrentPlayers] = useState<Player[]>([]);
+  const [selectedPlayerIds, setSelectedPlayerIds] = useState<string[]>([]);
+  const [playerSearch, setPlayerSearch] = useState('');
+
+  const [form, setForm] = useState({
+    clubId: '',
+    name: '',
+    ageCategory: '',
+    birthyear: 2010,
+    coach: '',
+  });
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [teamRes, clubsRes] = await Promise.all([
+          teamService.getTeamById(params.id as string),
+          clubService.getMyClubs(),
+        ]);
+
+        const team = (teamRes as any)?.data ?? teamRes;
+        setForm({
+          clubId: team.clubId,
+          name: team.name,
+          ageCategory: team.ageCategory,
+          birthyear: team.birthyear,
+          coach: team.coach,
+        });
+
+        const players = team.players || [];
+        setCurrentPlayers(players);
+        setSelectedPlayerIds(players.map((p: Player) => p.id));
+
+        const clubData = (clubsRes as any)?.data ?? clubsRes;
+        setClubs(Array.isArray(clubData) ? clubData : (clubData as any)?.data ?? []);
+      } catch (err: any) {
+        setError('Failed to load team');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [params.id]);
+
+  const searchPlayers = useCallback(async (query: string) => {
+    if (!query.trim()) {
+      setAvailablePlayers([]);
+      return;
+    }
+    try {
+      const res = await playerService.searchPlayers({ q: query, limit: 20 });
+      const data = (res as any)?.data ?? res;
+      setAvailablePlayers(Array.isArray(data) ? data : (data as any)?.data ?? []);
+    } catch { /* silently fail */ }
+  }, []);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => searchPlayers(playerSearch), 300);
+    return () => clearTimeout(timeout);
+  }, [playerSearch, searchPlayers]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      await teamService.updateTeam(params.id as string, {
+        ...form,
+        playerIds: selectedPlayerIds,
+      });
+      router.push(`/dashboard/teams/${params.id}`);
+    } catch (err: any) {
+      const msg = err?.response?.data?.error?.message || err?.message || 'Failed to update team';
+      setError(msg);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const togglePlayer = (playerId: string) => {
+    setSelectedPlayerIds((prev) =>
+      prev.includes(playerId) ? prev.filter((id) => id !== playerId) : [...prev, playerId]
+    );
+  };
+
+  const allKnownPlayers = [...currentPlayers, ...availablePlayers].reduce(
+    (acc, p) => {
+      if (!acc.find((x) => x.id === p.id)) acc.push(p);
+      return acc;
+    },
+    [] as Player[]
+  );
+
+  if (loading) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center min-h-[400px]">
+          <Loading size="lg" />
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-2xl mx-auto space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Edit Team</h1>
+          <p className="text-gray-600 mt-1">Update team details and players</p>
+        </div>
+
+        {error && <Alert variant="error">{error}</Alert>}
+
+        <form onSubmit={handleSubmit}>
+          <Card>
+            <CardHeader>
+              <CardTitle>Team Details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Club *</label>
+                <select
+                  className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2"
+                  value={form.clubId}
+                  onChange={(e) => setForm({ ...form, clubId: e.target.value })}
+                  required
+                >
+                  <option value="">Select a club</option>
+                  {clubs.map((club) => (
+                    <option key={club.id} value={club.id}>{club.name}</option>
+                  ))}
+                </select>
+              </div>
+
+              <Input
+                label="Team Name *"
+                placeholder="e.g. U17 A"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                required
+              />
+
+              <div className="grid grid-cols-2 gap-4">
+                <Input
+                  label="Age Category *"
+                  placeholder="e.g. U17"
+                  value={form.ageCategory}
+                  onChange={(e) => setForm({ ...form, ageCategory: e.target.value })}
+                  required
+                />
+                <Input
+                  type="number"
+                  label="Birth Year *"
+                  value={String(form.birthyear)}
+                  onChange={(e) => setForm({ ...form, birthyear: parseInt(e.target.value) || 0 })}
+                  required
+                />
+              </div>
+
+              <Input
+                label="Coach Name *"
+                placeholder="e.g. John Smith"
+                value={form.coach}
+                onChange={(e) => setForm({ ...form, coach: e.target.value })}
+                required
+              />
+            </CardContent>
+          </Card>
+
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>Manage Players</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {/* Currently assigned */}
+              {selectedPlayerIds.length > 0 && (
+                <div>
+                  <p className="text-sm font-medium text-gray-700 mb-2">
+                    Assigned Players ({selectedPlayerIds.length})
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {selectedPlayerIds.map((id) => {
+                      const player = allKnownPlayers.find((p) => p.id === id);
+                      return (
+                        <span
+                          key={id}
+                          className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-primary/10 text-primary text-sm"
+                        >
+                          {player ? `${player.firstname} ${player.lastname}` : id.substring(0, 8)}
+                          <button
+                            type="button"
+                            onClick={() => togglePlayer(id)}
+                            className="ml-1 text-primary/60 hover:text-primary"
+                          >
+                            &times;
+                          </button>
+                        </span>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {/* Search to add more */}
+              <Input
+                placeholder="Search players to add..."
+                value={playerSearch}
+                onChange={(e) => setPlayerSearch(e.target.value)}
+              />
+
+              {availablePlayers.length > 0 && (
+                <div className="border rounded-lg divide-y max-h-60 overflow-y-auto">
+                  {availablePlayers
+                    .filter((p) => !selectedPlayerIds.includes(p.id))
+                    .map((player) => (
+                      <label
+                        key={player.id}
+                        className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 cursor-pointer"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={selectedPlayerIds.includes(player.id)}
+                          onChange={() => togglePlayer(player.id)}
+                          className="rounded border-gray-300"
+                        />
+                        <span className="text-sm font-medium text-gray-900">
+                          {player.firstname} {player.lastname}
+                        </span>
+                        <span className="text-xs text-gray-500">
+                          Born: {new Date(player.dateOfBirth).toLocaleDateString()}
+                        </span>
+                      </label>
+                    ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <div className="flex justify-end gap-3 mt-6">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => router.push(`/dashboard/teams/${params.id}`)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" isLoading={saving}>
+              Save Changes
+            </Button>
+          </div>
+        </form>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/dashboard/teams/[id]/page.tsx
+++ b/src/app/dashboard/teams/[id]/page.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+import { DashboardLayout } from '@/components/layout';
+import { Card, CardHeader, CardTitle, CardContent, Button, Badge, Alert, Loading, Tabs } from '@/components/ui';
+import { teamService } from '@/services';
+import type { Team } from '@/types';
+
+export default function TeamDetailPage() {
+  const { t } = useTranslation();
+  const params = useParams();
+  const router = useRouter();
+  const [team, setTeam] = useState<Team | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchTeam();
+  }, [params.id]);
+
+  const fetchTeam = async () => {
+    try {
+      setLoading(true);
+      const res = await teamService.getTeamById(params.id as string);
+      const data = (res as any)?.data ?? res;
+      setTeam(data);
+    } catch (err: any) {
+      setError('Failed to load team');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!team || !confirm('Are you sure you want to delete this team?')) return;
+    try {
+      await teamService.deleteTeam(team.id);
+      router.push('/dashboard/teams');
+    } catch (err: any) {
+      setError('Failed to delete team');
+    }
+  };
+
+  if (loading) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center min-h-[400px]">
+          <Loading size="lg" />
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  if (!team) {
+    return (
+      <DashboardLayout>
+        <Alert variant="error">{error || 'Team not found'}</Alert>
+      </DashboardLayout>
+    );
+  }
+
+  const tabs = [
+    {
+      id: 'overview',
+      label: 'Overview',
+      content: (
+        <div className="space-y-6">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4">
+            <Card>
+              <CardContent className="p-3 sm:p-4 text-center">
+                <p className="text-xs sm:text-sm text-gray-500">Age Category</p>
+                <p className="text-xl sm:text-2xl font-bold text-primary">{team.ageCategory}</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-3 sm:p-4 text-center">
+                <p className="text-xs sm:text-sm text-gray-500">Birth Year</p>
+                <p className="text-xl sm:text-2xl font-bold">{team.birthyear}</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-3 sm:p-4 text-center">
+                <p className="text-xs sm:text-sm text-gray-500">Coach</p>
+                <p className="text-lg sm:text-xl font-bold truncate">{team.coach}</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-3 sm:p-4 text-center">
+                <p className="text-xs sm:text-sm text-gray-500">Players</p>
+                <p className="text-xl sm:text-2xl font-bold">{team.players?.length || 0}</p>
+              </CardContent>
+            </Card>
+          </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Team Information</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <p className="text-sm text-gray-500">Club</p>
+                  <p className="font-medium">
+                    {team.club ? (
+                      <Link href={`/dashboard/clubs/${team.club.id}`} className="text-primary hover:underline">
+                        {team.club.name}
+                      </Link>
+                    ) : '-'}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-sm text-gray-500">Coach</p>
+                  <p className="font-medium">{team.coach}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-gray-500">Age Category</p>
+                  <p className="font-medium">{team.ageCategory}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-gray-500">Birth Year</p>
+                  <p className="font-medium">{team.birthyear}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      ),
+    },
+    {
+      id: 'players',
+      label: `Players (${team.players?.length || 0})`,
+      content: (
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle>Players</CardTitle>
+            <Link href={`/dashboard/teams/${team.id}/edit`}>
+              <Button variant="primary" size="sm">
+                <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                Manage Players
+              </Button>
+            </Link>
+          </CardHeader>
+          <CardContent className="p-0">
+            {!team.players || team.players.length === 0 ? (
+              <div className="text-center py-12">
+                <svg className="w-16 h-16 mx-auto text-gray-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+                </svg>
+                <h3 className="text-lg font-medium text-gray-900 mb-2">No players assigned</h3>
+                <p className="text-gray-500 mb-4">Edit this team to assign players</p>
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date of Birth</th>
+                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {team.players.map((player) => (
+                      <tr key={player.id} className="hover:bg-gray-50">
+                        <td className="px-6 py-4 whitespace-nowrap font-medium text-gray-900">
+                          <Link href={`/dashboard/players/${player.id}`} className="hover:text-primary">
+                            {player.firstname} {player.lastname}
+                          </Link>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                          {new Date(player.dateOfBirth).toLocaleDateString()}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-right">
+                          <Link href={`/dashboard/players/${player.id}/edit`}>
+                            <Button variant="outline" size="sm">Edit</Button>
+                          </Link>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      ),
+    },
+  ];
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        {error && <Alert variant="error">{error}</Alert>}
+
+        {/* Header */}
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <div className="w-16 h-16 bg-primary/10 rounded-lg flex items-center justify-center">
+              <span className="text-2xl font-bold text-primary">{team.name.charAt(0)}</span>
+            </div>
+            <div>
+              <div className="flex items-center gap-3">
+                <h1 className="text-2xl font-bold text-gray-900">{team.name}</h1>
+                <Badge variant="info">{team.ageCategory}</Badge>
+              </div>
+              <p className="text-gray-600 mt-1">
+                {team.club?.name || 'Unknown Club'} &middot; Birth Year {team.birthyear}
+              </p>
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Link href={`/dashboard/teams/${team.id}/edit`}>
+              <Button variant="primary">
+                <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                </svg>
+                Edit
+              </Button>
+            </Link>
+            <Button
+              variant="ghost"
+              onClick={handleDelete}
+              className="text-red-600 hover:text-red-800"
+            >
+              <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+              Delete
+            </Button>
+          </div>
+        </div>
+
+        <Tabs tabs={tabs} defaultTab="overview" />
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/dashboard/teams/create/page.tsx
+++ b/src/app/dashboard/teams/create/page.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import { DashboardLayout } from '@/components/layout';
+import { Card, CardHeader, CardTitle, CardContent, Button, Input, Alert } from '@/components/ui';
+import { teamService, clubService, playerService } from '@/services';
+import type { Club, Player } from '@/types';
+
+export default function CreateTeamPage() {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [clubs, setClubs] = useState<Club[]>([]);
+  const [availablePlayers, setAvailablePlayers] = useState<Player[]>([]);
+  const [selectedPlayerIds, setSelectedPlayerIds] = useState<string[]>([]);
+  const [playerSearch, setPlayerSearch] = useState('');
+
+  const [form, setForm] = useState({
+    clubId: '',
+    name: '',
+    ageCategory: '',
+    birthyear: new Date().getFullYear() - 15,
+    coach: '',
+  });
+
+  useEffect(() => {
+    const fetchClubs = async () => {
+      try {
+        const res = await clubService.getMyClubs();
+        const data = (res as any)?.data ?? res;
+        setClubs(Array.isArray(data) ? data : (data as any)?.data ?? []);
+      } catch { /* silently fail */ }
+    };
+    fetchClubs();
+  }, []);
+
+  const searchPlayers = useCallback(async (query: string) => {
+    if (!query.trim()) {
+      setAvailablePlayers([]);
+      return;
+    }
+    try {
+      const res = await playerService.searchPlayers({ q: query, limit: 20 });
+      const data = (res as any)?.data ?? res;
+      setAvailablePlayers(Array.isArray(data) ? data : (data as any)?.data ?? []);
+    } catch { /* silently fail */ }
+  }, []);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => searchPlayers(playerSearch), 300);
+    return () => clearTimeout(timeout);
+  }, [playerSearch, searchPlayers]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.clubId || !form.name || !form.ageCategory || !form.coach) {
+      setError('Please fill in all required fields');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      await teamService.createTeam({
+        ...form,
+        playerIds: selectedPlayerIds.length > 0 ? selectedPlayerIds : undefined,
+      });
+      router.push('/dashboard/teams');
+    } catch (err: any) {
+      const msg = err?.response?.data?.error?.message || err?.message || 'Failed to create team';
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const togglePlayer = (playerId: string) => {
+    setSelectedPlayerIds((prev) =>
+      prev.includes(playerId) ? prev.filter((id) => id !== playerId) : [...prev, playerId]
+    );
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-2xl mx-auto space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Create Team</h1>
+          <p className="text-gray-600 mt-1">Add a new team to one of your clubs</p>
+        </div>
+
+        {error && <Alert variant="error">{error}</Alert>}
+
+        <form onSubmit={handleSubmit}>
+          <Card>
+            <CardHeader>
+              <CardTitle>Team Details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Club *</label>
+                <select
+                  className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2"
+                  value={form.clubId}
+                  onChange={(e) => setForm({ ...form, clubId: e.target.value })}
+                  required
+                >
+                  <option value="">Select a club</option>
+                  {clubs.map((club) => (
+                    <option key={club.id} value={club.id}>{club.name}</option>
+                  ))}
+                </select>
+              </div>
+
+              <Input
+                label="Team Name *"
+                placeholder="e.g. U17 A"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                required
+              />
+
+              <div className="grid grid-cols-2 gap-4">
+                <Input
+                  label="Age Category *"
+                  placeholder="e.g. U17"
+                  value={form.ageCategory}
+                  onChange={(e) => setForm({ ...form, ageCategory: e.target.value })}
+                  required
+                />
+                <Input
+                  type="number"
+                  label="Birth Year *"
+                  value={String(form.birthyear)}
+                  onChange={(e) => setForm({ ...form, birthyear: parseInt(e.target.value) || 0 })}
+                  required
+                />
+              </div>
+
+              <Input
+                label="Coach Name *"
+                placeholder="e.g. John Smith"
+                value={form.coach}
+                onChange={(e) => setForm({ ...form, coach: e.target.value })}
+                required
+              />
+            </CardContent>
+          </Card>
+
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>Assign Players (Optional)</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <Input
+                placeholder="Search players by name..."
+                value={playerSearch}
+                onChange={(e) => setPlayerSearch(e.target.value)}
+              />
+
+              {selectedPlayerIds.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {selectedPlayerIds.map((id) => {
+                    const player = availablePlayers.find((p) => p.id === id);
+                    return (
+                      <span
+                        key={id}
+                        className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-primary/10 text-primary text-sm"
+                      >
+                        {player ? `${player.firstname} ${player.lastname}` : id}
+                        <button
+                          type="button"
+                          onClick={() => togglePlayer(id)}
+                          className="ml-1 text-primary/60 hover:text-primary"
+                        >
+                          &times;
+                        </button>
+                      </span>
+                    );
+                  })}
+                </div>
+              )}
+
+              {availablePlayers.length > 0 && (
+                <div className="border rounded-lg divide-y max-h-60 overflow-y-auto">
+                  {availablePlayers.map((player) => (
+                    <label
+                      key={player.id}
+                      className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedPlayerIds.includes(player.id)}
+                        onChange={() => togglePlayer(player.id)}
+                        className="rounded border-gray-300"
+                      />
+                      <span className="text-sm font-medium text-gray-900">
+                        {player.firstname} {player.lastname}
+                      </span>
+                      <span className="text-xs text-gray-500">
+                        Born: {new Date(player.dateOfBirth).toLocaleDateString()}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <div className="flex justify-end gap-3 mt-6">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => router.push('/dashboard/teams')}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" isLoading={loading}>
+              Create Team
+            </Button>
+          </div>
+        </form>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/dashboard/teams/page.tsx
+++ b/src/app/dashboard/teams/page.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+import { DashboardLayout } from '@/components/layout';
+import { Card, CardContent, Button, Badge, Loading, Input, Alert } from '@/components/ui';
+import { teamService, clubService } from '@/services';
+import type { Team, Club } from '@/types';
+
+export default function TeamsPage() {
+  const { t } = useTranslation();
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [clubs, setClubs] = useState<Club[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [selectedClubId, setSelectedClubId] = useState<string>('');
+
+  const fetchTeams = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await teamService.getAllTeams({
+        clubId: selectedClubId || undefined,
+        search: search || undefined,
+      });
+      const data = (res as any)?.data ?? res;
+      setTeams(Array.isArray(data) ? data : (data as any)?.data ?? []);
+    } catch (err: any) {
+      setError(err?.message || 'Failed to load teams');
+    } finally {
+      setLoading(false);
+    }
+  }, [search, selectedClubId]);
+
+  const fetchClubs = useCallback(async () => {
+    try {
+      const res = await clubService.getMyClubs();
+      const data = (res as any)?.data ?? res;
+      const clubList = Array.isArray(data) ? data : (data as any)?.data ?? [];
+      setClubs(clubList);
+    } catch {
+      // silently fail - clubs dropdown optional
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchClubs();
+  }, [fetchClubs]);
+
+  useEffect(() => {
+    fetchTeams();
+  }, [fetchTeams]);
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Are you sure you want to delete this team?')) return;
+    try {
+      await teamService.deleteTeam(id);
+      setTeams((prev) => prev.filter((t) => t.id !== id));
+    } catch (err: any) {
+      setError(err?.message || 'Failed to delete team');
+    }
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <h1 className="text-xl sm:text-2xl font-bold text-gray-900">
+              {t('nav.teams', 'Teams')}
+            </h1>
+            <p className="text-sm sm:text-base text-gray-600 mt-1">
+              Manage your teams and assign players
+            </p>
+          </div>
+          <Link href="/dashboard/teams/create" className="self-start sm:self-auto">
+            <Button variant="primary">
+              <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+              Create Team
+            </Button>
+          </Link>
+        </div>
+
+        {/* Filters */}
+        <div className="flex flex-col sm:flex-row gap-3">
+          <div className="flex-1">
+            <Input
+              placeholder="Search teams..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
+          <select
+            className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm"
+            value={selectedClubId}
+            onChange={(e) => setSelectedClubId(e.target.value)}
+          >
+            <option value="">All Clubs</option>
+            {clubs.map((club) => (
+              <option key={club.id} value={club.id}>{club.name}</option>
+            ))}
+          </select>
+        </div>
+
+        {error && <Alert variant="error">{error}</Alert>}
+
+        {/* Content */}
+        {loading ? (
+          <div className="flex justify-center py-12">
+            <Loading size="lg" />
+          </div>
+        ) : teams.length === 0 ? (
+          <Card>
+            <CardContent className="text-center py-12">
+              <svg className="w-16 h-16 mx-auto text-gray-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+              </svg>
+              <h3 className="text-lg font-medium text-gray-900 mb-2">No teams yet</h3>
+              <p className="text-gray-500 mb-4">Create your first team to get started</p>
+              <Link href="/dashboard/teams/create">
+                <Button variant="primary">Create First Team</Button>
+              </Link>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+            {teams.map((team) => (
+              <Card key={team.id} className="hover:shadow-lg transition-shadow">
+                <CardContent className="p-4 sm:p-6">
+                  <div className="flex items-start justify-between">
+                    <div className="flex-1 min-w-0">
+                      <Link
+                        href={`/dashboard/teams/${team.id}`}
+                        className="font-semibold text-gray-900 hover:text-primary text-lg"
+                      >
+                        {team.name}
+                      </Link>
+                      {team.club && (
+                        <p className="text-sm text-gray-500 mt-1">{team.club.name}</p>
+                      )}
+                    </div>
+                    <Badge variant="info">{team.ageCategory}</Badge>
+                  </div>
+
+                  <div className="mt-4 space-y-2">
+                    <div className="flex items-center text-sm text-gray-600">
+                      <svg className="w-4 h-4 mr-2 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                      </svg>
+                      Birth Year: {team.birthyear}
+                    </div>
+                    <div className="flex items-center text-sm text-gray-600">
+                      <svg className="w-4 h-4 mr-2 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                      </svg>
+                      Coach: {team.coach}
+                    </div>
+                    <div className="flex items-center text-sm text-gray-600">
+                      <svg className="w-4 h-4 mr-2 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+                      </svg>
+                      Players: {team.players?.length || 0}
+                    </div>
+                  </div>
+
+                  <div className="flex gap-2 mt-4 pt-4 border-t border-gray-200">
+                    <Link href={`/dashboard/teams/${team.id}`} className="flex-1">
+                      <Button variant="outline" size="sm" className="w-full">
+                        {t('common.view', 'View')}
+                      </Button>
+                    </Link>
+                    <Link href={`/dashboard/teams/${team.id}/edit`} className="flex-1">
+                      <Button variant="primary" size="sm" className="w-full">
+                        {t('common.edit', 'Edit')}
+                      </Button>
+                    </Link>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleDelete(team.id)}
+                      className="text-red-600 hover:text-red-800"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                      </svg>
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/dashboard/tournaments/[id]/page.tsx
+++ b/src/app/dashboard/tournaments/[id]/page.tsx
@@ -244,7 +244,10 @@ export default function TournamentDetailPage() {
             <tr key={registration.id}>
               <td className="px-6 py-4 whitespace-nowrap">
                 <div className="font-medium text-gray-900">
-                  {registration.club?.name || registration.coachName || '-'}
+                  Team: {registration.team?.name || 'Not specified'}
+                </div>
+                <div className="text-sm text-gray-500">
+                  Club: {registration.club?.name || registration.coachName || '-'}
                 </div>
                 {registration.coachPhone && (
                   <div className="text-sm text-gray-500">{registration.coachPhone}</div>

--- a/src/app/dashboard/tournaments/[id]/pots/page.tsx
+++ b/src/app/dashboard/tournaments/[id]/pots/page.tsx
@@ -371,6 +371,7 @@ export default function PotManagementPage() {
                   >
                     <div className="flex-1">
                       <p className="font-medium">{reg.club?.name || 'Unknown Club'}</p>
+                      <p className="text-sm text-gray-600">Team: {reg.team?.name || 'Not specified'}</p>
                       <p className="text-sm text-gray-600">{reg.coachName}</p>
                       {assignedPot && (
                         <Badge variant="success" className="mt-1">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -49,6 +49,24 @@ export default function Sidebar() {
       ),
     },
     {
+      name: t('nav.teams', 'Teams'),
+      href: '/dashboard/teams',
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+        </svg>
+      ),
+    },
+    {
+      name: t('nav.players', 'Players'),
+      href: '/dashboard/players',
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+        </svg>
+      ),
+    },
+    {
       name: t('nav.registrations'),
       href: '/dashboard/registrations',
       icon: (

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -34,5 +34,8 @@ export * from './location.service';
 export { default as teamService } from './team.service';
 export * from './team.service';
 
+export { default as playerService } from './player.service';
+export * from './player.service';
+
 export { potDrawService } from './pot-draw.service';
 export * from './pot-draw.service';

--- a/src/services/player.service.ts
+++ b/src/services/player.service.ts
@@ -1,0 +1,71 @@
+import { apiGet, apiPost, apiPatch, apiDelete } from './api';
+import type { ApiResponse, Player, CreatePlayerDto, UpdatePlayerDto, PlayerAutocomplete } from '@/types';
+
+const PLAYERS_BASE = '/v1/players';
+
+export async function getPlayers(params?: {
+  teamId?: string;
+  search?: string;
+  page?: number;
+  pageSize?: number;
+}): Promise<ApiResponse<Player[]>> {
+  const query = new URLSearchParams();
+  if (params?.teamId) query.set('teamId', params.teamId);
+  if (params?.search) query.set('search', params.search);
+  if (params?.page) query.set('page', String(params.page));
+  if (params?.pageSize) query.set('pageSize', String(params.pageSize));
+  const qs = query.toString();
+  return apiGet<ApiResponse<Player[]>>(`${PLAYERS_BASE}${qs ? `?${qs}` : ''}`);
+}
+
+export async function getPlayerById(id: string): Promise<ApiResponse<Player>> {
+  return apiGet<ApiResponse<Player>>(`${PLAYERS_BASE}/${id}`);
+}
+
+export async function createPlayer(data: CreatePlayerDto): Promise<ApiResponse<Player>> {
+  return apiPost<ApiResponse<Player>>(PLAYERS_BASE, data);
+}
+
+export async function updatePlayer(id: string, data: UpdatePlayerDto): Promise<ApiResponse<Player>> {
+  return apiPatch<ApiResponse<Player>>(`${PLAYERS_BASE}/${id}`, data);
+}
+
+export async function deletePlayer(id: string): Promise<ApiResponse<void>> {
+  return apiDelete<ApiResponse<void>>(`${PLAYERS_BASE}/${id}`);
+}
+
+export async function searchPlayers(params: {
+  q: string;
+  teamId?: string;
+  limit?: number;
+}): Promise<ApiResponse<Player[]>> {
+  const query = new URLSearchParams();
+  query.set('q', params.q);
+  if (params.teamId) query.set('teamId', params.teamId);
+  if (params.limit) query.set('limit', String(params.limit));
+  return apiGet<ApiResponse<Player[]>>(`${PLAYERS_BASE}/search?${query.toString()}`);
+}
+
+export async function autocompletePlayer(params: {
+  q: string;
+  teamId?: string;
+  limit?: number;
+}): Promise<ApiResponse<PlayerAutocomplete[]>> {
+  const query = new URLSearchParams();
+  query.set('q', params.q);
+  if (params.teamId) query.set('teamId', params.teamId);
+  if (params.limit) query.set('limit', String(params.limit));
+  return apiGet<ApiResponse<PlayerAutocomplete[]>>(`${PLAYERS_BASE}/autocomplete?${query.toString()}`);
+}
+
+export const playerService = {
+  getPlayers,
+  getPlayerById,
+  createPlayer,
+  updatePlayer,
+  deletePlayer,
+  searchPlayers,
+  autocompletePlayer,
+};
+
+export default playerService;

--- a/src/services/team.service.ts
+++ b/src/services/team.service.ts
@@ -1,5 +1,5 @@
-import { apiGet, apiPost } from './api';
-import type { ApiResponse, Team, CreateTeamDto } from '@/types';
+import { apiGet, apiPost, apiPatch, apiDelete } from './api';
+import type { ApiResponse, Team, CreateTeamDto, UpdateTeamDto } from '@/types';
 
 const TEAMS_BASE = '/v1/teams';
 
@@ -7,13 +7,53 @@ export async function getTeamsByClub(clubId: string): Promise<ApiResponse<Team[]
   return apiGet<ApiResponse<Team[]>>(`${TEAMS_BASE}?clubId=${encodeURIComponent(clubId)}`);
 }
 
+export async function getAllTeams(params?: {
+  clubId?: string;
+  search?: string;
+}): Promise<ApiResponse<Team[]>> {
+  const query = new URLSearchParams();
+  if (params?.clubId) query.set('clubId', params.clubId);
+  if (params?.search) query.set('search', params.search);
+  const qs = query.toString();
+  return apiGet<ApiResponse<Team[]>>(`${TEAMS_BASE}${qs ? `?${qs}` : ''}`);
+}
+
+export async function getTeamById(id: string): Promise<ApiResponse<Team>> {
+  return apiGet<ApiResponse<Team>>(`${TEAMS_BASE}/${id}`);
+}
+
 export async function createTeam(data: CreateTeamDto): Promise<ApiResponse<Team>> {
   return apiPost<ApiResponse<Team>>(TEAMS_BASE, data);
 }
 
+export async function updateTeam(id: string, data: UpdateTeamDto): Promise<ApiResponse<Team>> {
+  return apiPatch<ApiResponse<Team>>(`${TEAMS_BASE}/${id}`, data);
+}
+
+export async function deleteTeam(id: string): Promise<ApiResponse<void>> {
+  return apiDelete<ApiResponse<void>>(`${TEAMS_BASE}/${id}`);
+}
+
+export async function searchTeams(params: {
+  q: string;
+  clubId?: string;
+  limit?: number;
+}): Promise<ApiResponse<Team[]>> {
+  const query = new URLSearchParams();
+  query.set('q', params.q);
+  if (params.clubId) query.set('clubId', params.clubId);
+  if (params.limit) query.set('limit', String(params.limit));
+  return apiGet<ApiResponse<Team[]>>(`${TEAMS_BASE}/search?${query.toString()}`);
+}
+
 export const teamService = {
   getTeamsByClub,
+  getAllTeams,
+  getTeamById,
   createTeam,
+  updateTeam,
+  deleteTeam,
+  searchTeams,
 };
 
 export default teamService;

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -1,12 +1,26 @@
+export interface Player {
+  id: string;
+  firstname: string;
+  lastname: string;
+  dateOfBirth: string;
+  teams?: Team[];
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface Team {
   id: string;
   name: string;
+  ageCategory: string;
+  birthyear: number;
+  coach: string;
   clubId: string;
   club?: {
     id: string;
     name: string;
     logo?: string;
   };
+  players?: Player[];
   createdAt: string;
   updatedAt: string;
 }
@@ -14,4 +28,38 @@ export interface Team {
 export interface CreateTeamDto {
   clubId: string;
   name: string;
+  ageCategory: string;
+  birthyear: number;
+  coach: string;
+  playerIds?: string[];
+}
+
+export interface UpdateTeamDto {
+  clubId?: string;
+  name?: string;
+  ageCategory?: string;
+  birthyear?: number;
+  coach?: string;
+  playerIds?: string[];
+}
+
+export interface CreatePlayerDto {
+  firstname: string;
+  lastname: string;
+  dateOfBirth: string;
+  teamIds?: string[];
+}
+
+export interface UpdatePlayerDto {
+  firstname?: string;
+  lastname?: string;
+  dateOfBirth?: string;
+  teamIds?: string[];
+}
+
+export interface PlayerAutocomplete {
+  id: string;
+  firstname: string;
+  lastname: string;
+  label: string;
 }


### PR DESCRIPTION
## Summary
Implements the frontend UI for **Issue #87 - Teams and Players entities and endpoints**.

## Changes

### New Pages (8)
- **Teams List** (`/dashboard/teams`) — Grid cards with search + club filter, delete support
- **Create Team** (`/dashboard/teams/create`) — Form with club selector, age category, birth year, coach, player search/assignment
- **Team Detail** (`/dashboard/teams/[id]`) — Overview tab (stats cards + info) + Players tab (table with links)
- **Edit Team** (`/dashboard/teams/[id]/edit`) — Pre-populated form with player management
- **Players List** (`/dashboard/players`) — Table view with name, DOB, age, team badges, actions
- **Create Player** (`/dashboard/players/create`) — Form with team assignment checkboxes
- **Player Detail** (`/dashboard/players/[id]`) — Info card + Teams card with links
- **Edit Player** (`/dashboard/players/[id]/edit`) — Pre-populated form with team assignment

### New Service
- `player.service.ts` — Full CRUD + search + autocomplete

### Modified Files
- `team.service.ts` — Added `getAllTeams`, `getTeamById`, `updateTeam`, `deleteTeam`, `searchTeams`
- `types/team.ts` — Added `Player` interface, expanded `Team` with `ageCategory`/`birthyear`/`coach`/`players`, added DTOs
- `services/index.ts` — Added `playerService` exports
- `Sidebar.tsx` — Added Teams & Players nav items with icons
- `clubs/[id]/page.tsx` — Replaced old hardcoded players tab with real teams data from API
- `dashboard/page.tsx`, `registrations/[id]/page.tsx`, `tournaments/[id]/page.tsx`, `tournaments/[id]/pots/page.tsx` — Show team name in registration context

### Testing
- Manually tested all pages on desktop (1280x720) and mobile (375x812)
- 13 screenshots captured in `notes/issue-87/screenshots/2026-02-15/`

Closes #87