### PR TITLE
feat: Issue #88 pending payment and mark-as-paid UI flow (frontend)

### DIFF
--- a/src/app/dashboard/registrations/[id]/page.tsx
+++ b/src/app/dashboard/registrations/[id]/page.tsx
@@ -49,6 +49,7 @@ export default function RegistrationDetailPage() {
   const getStatusBadge = (status: RegistrationStatus) => {
     const variants: Record<RegistrationStatus, 'default' | 'success' | 'warning' | 'danger' | 'info'> = {
       'PENDING': 'warning',
+      'PENDING_PAYMENT': 'info',
       'APPROVED': 'success',
       'REJECTED': 'danger',
       'WITHDRAWN': 'default',
@@ -126,7 +127,7 @@ export default function RegistrationDetailPage() {
               Registration Details
             </h1>
           </div>
-          {registration.status === 'PENDING' && (
+          {(registration.status === 'PENDING' || registration.status === 'PENDING_PAYMENT') && (
             <Button variant="danger" onClick={handleWithdraw} className="self-start sm:self-auto">
               Withdraw Registration
             </Button>
@@ -137,6 +138,7 @@ export default function RegistrationDetailPage() {
         <Card className={`border-l-4 ${
           registration.status === 'APPROVED' ? 'border-l-green-500' :
           registration.status === 'PENDING' ? 'border-l-yellow-500' :
+          registration.status === 'PENDING_PAYMENT' ? 'border-l-blue-500' :
           registration.status === 'REJECTED' ? 'border-l-red-500' :
           'border-l-gray-500'
         }`}>
@@ -170,6 +172,7 @@ export default function RegistrationDetailPage() {
                   </p>
                   <p className="text-sm text-gray-500">
                     {registration.status === 'PENDING' && 'Your registration is being reviewed'}
+                    {registration.status === 'PENDING_PAYMENT' && 'Your registration is approved but awaiting payment'}
                     {registration.status === 'APPROVED' && 'Your registration has been approved'}
                     {registration.status === 'REJECTED' && (registration as any).rejectionReason}
                   </p>
@@ -283,8 +286,13 @@ export default function RegistrationDetailPage() {
               <div>
                 <p className="text-sm text-gray-500">Entry Fee</p>
                 <p className="text-2xl font-bold text-gray-900">
-                  {formatCurrency(tournament?.entryFee || 0)}
+                  {registration.priceAmount != null && Number(registration.priceAmount) > 0
+                    ? `${registration.priceCurrency || 'EUR'} ${Number(registration.priceAmount).toFixed(2)}`
+                    : formatCurrency(tournament?.entryFee || 0)}
                 </p>
+                {registration.paid && registration.paidAmount != null && (
+                  <p className="text-sm text-green-600 mt-1">Paid: {registration.priceCurrency || 'EUR'} {Number(registration.paidAmount).toFixed(2)}</p>
+                )}
               </div>
               <div className="text-right">
                 <p className="text-sm text-gray-500 mb-1">Payment Status</p>
@@ -293,7 +301,7 @@ export default function RegistrationDetailPage() {
                 </Badge>
               </div>
             </div>
-            {registration.status === 'APPROVED' && registration.paymentStatus !== 'COMPLETED' && (
+            {(registration.status === 'APPROVED' || registration.status === 'PENDING_PAYMENT') && registration.paymentStatus !== 'COMPLETED' && (
               <div className="mt-4">
                 <Button variant="primary" className="w-full">
                   <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/app/dashboard/registrations/page.tsx
+++ b/src/app/dashboard/registrations/page.tsx
@@ -50,7 +50,7 @@ export default function RegistrationsPage() {
     setSummaryCounts({
       total: registrationData.length,
       approved: registrationData.filter((reg) => reg.status === 'APPROVED').length,
-      pending: registrationData.filter((reg) => reg.status === 'PENDING').length,
+      pending: registrationData.filter((reg) => reg.status === 'PENDING' || reg.status === 'PENDING_PAYMENT').length,
     });
     
     // Apply client-side filter since backend doesn't support it
@@ -91,6 +91,7 @@ export default function RegistrationsPage() {
   const getStatusBadge = (status: RegistrationStatus) => {
     const variants: Record<RegistrationStatus, 'default' | 'success' | 'warning' | 'danger' | 'info'> = {
       'PENDING': 'warning',
+      'PENDING_PAYMENT': 'info',
       'APPROVED': 'success',
       'REJECTED': 'danger',
       'WITHDRAWN': 'default',
@@ -122,6 +123,7 @@ export default function RegistrationsPage() {
   const tabs = [
     { id: 'all', label: t('common.all') },
     { id: 'PENDING', label: t('registration.status.PENDING') },
+    { id: 'PENDING_PAYMENT', label: t('registration.status.PENDING_PAYMENT', 'Pending Payment') },
     { id: 'APPROVED', label: t('registration.status.APPROVED') },
     { id: 'REJECTED', label: t('registration.status.REJECTED') },
   ];
@@ -290,7 +292,7 @@ export default function RegistrationsPage() {
                             {t('common.view')}
                           </Button>
                         </Link>
-                        {registration.status === 'PENDING' && (
+                        {(registration.status === 'PENDING' || registration.status === 'PENDING_PAYMENT') && (
                           <Button
                             variant="danger"
                             size="sm"

--- a/src/app/dashboard/tournaments/[id]/page.tsx
+++ b/src/app/dashboard/tournaments/[id]/page.tsx
@@ -105,6 +105,7 @@ export default function TournamentDetailPage() {
   const getRegistrationStatusBadge = (status: RegistrationStatus) => {
     const variants: Record<RegistrationStatus, 'default' | 'success' | 'warning' | 'danger' | 'info'> = {
       'PENDING': 'warning',
+      'PENDING_PAYMENT': 'info',
       'APPROVED': 'success',
       'REJECTED': 'danger',
       'WITHDRAWN': 'default',
@@ -127,6 +128,15 @@ export default function TournamentDetailPage() {
       fetchData();
     } catch (err: any) {
       setError('Failed to approve registration without payment');
+    }
+  };
+
+  const handleMarkAsPaid = async (registrationId: string) => {
+    try {
+      await registrationService.markRegistrationAsPaid(registrationId);
+      fetchData();
+    } catch (err: any) {
+      setError('Failed to mark registration as paid');
     }
   };
 
@@ -313,6 +323,22 @@ export default function TournamentDetailPage() {
                       onClick={() => handleRejectRegistration(registration.id)}
                     >
                       {t('registration.reject')}
+                    </Button>
+                  </>
+                )}
+                {registration.status === 'PENDING_PAYMENT' && (
+                  <>
+                    {registration.priceAmount != null && Number(registration.priceAmount) > 0 && (
+                      <span className="text-sm font-medium text-amber-700 bg-amber-50 px-2 py-1 rounded">
+                        {registration.priceCurrency || 'EUR'} {Number(registration.priceAmount).toFixed(2)}
+                      </span>
+                    )}
+                    <Button
+                      size="sm"
+                      variant="paid"
+                      onClick={() => handleMarkAsPaid(registration.id)}
+                    >
+                      {t('registration.markAsPaid', 'Mark as Paid')}
                     </Button>
                   </>
                 )}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -297,6 +297,7 @@
       "noSpotsAvailable": "No spots available.",
       "status": {
         "PENDING": "Pending",
+        "PENDING_PAYMENT": "Pending Payment",
         "APPROVED": "Approved",
         "REJECTED": "Rejected",
         "WITHDRAWN": "Withdrawn"
@@ -414,6 +415,7 @@
       "notRegisteredDesc": "You haven't registered for this tournament yet.",
       "registered": "Registered",
       "PENDING": "Pending",
+      "PENDING_PAYMENT": "Pending Payment",
       "APPROVED": "Approved",
       "REJECTED": "Rejected",
       "WITHDRAWN": "Withdrawn"

--- a/src/i18n/locales/ro.json
+++ b/src/i18n/locales/ro.json
@@ -331,6 +331,7 @@
       "noSpotsAvailable": "Nu mai sunt locuri disponibile.",
       "status": {
         "PENDING": "În așteptare",
+        "PENDING_PAYMENT": "Plată în așteptare",
         "APPROVED": "Aprobat",
         "REJECTED": "Respins",
         "WITHDRAWN": "Retras"
@@ -445,6 +446,7 @@
       "notRegisteredDesc": "Nu te-ai înregistrat încă la acest turneu.",
       "registered": "Înregistrat",
       "PENDING": "În așteptare",
+      "PENDING_PAYMENT": "Plată în așteptare",
       "APPROVED": "Aprobat",
       "REJECTED": "Respins",
       "WITHDRAWN": "Retras"

--- a/src/services/registration.service.ts
+++ b/src/services/registration.service.ts
@@ -19,6 +19,7 @@ import type {
   ConfirmFitnessDto,
   FitnessStatus,
   RegistrationWithDetails,
+  MarkAsPaidDto,
 } from '@/types';
 
 // Register a team for a tournament
@@ -186,6 +187,17 @@ export async function withdrawRegistration(id: string): Promise<ApiResponse<Regi
   return apiPost<ApiResponse<Registration>>(`/v1/registrations/${id}/withdraw`);
 }
 
+// Mark registration as paid (Issue #88)
+export async function markRegistrationAsPaid(
+  id: string,
+  data?: MarkAsPaidDto
+): Promise<ApiResponse<Registration>> {
+  return apiPost<ApiResponse<Registration>>(
+    `/v1/registrations/${id}/mark-as-paid`,
+    data || {}
+  );
+}
+
 // Get my registration for a tournament
 export async function getMyRegistration(tournamentId: string): Promise<ApiResponse<RegistrationWithDetails>> {
   return apiGet<ApiResponse<RegistrationWithDetails>>(`/v1/tournaments/${tournamentId}/my-registration`);
@@ -274,6 +286,7 @@ export const registrationService = {
   bulkApproveRegistrations,
   bulkRejectRegistrations,
   withdrawRegistration,
+  markRegistrationAsPaid,
   // Document methods
   uploadDocument,
   getDocuments,

--- a/src/types/registration.ts
+++ b/src/types/registration.ts
@@ -1,5 +1,5 @@
 // Registration types
-export type RegistrationStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'WITHDRAWN';
+export type RegistrationStatus = 'PENDING' | 'PENDING_PAYMENT' | 'APPROVED' | 'REJECTED' | 'WITHDRAWN';
 
 // Import PaymentStatus from payment.ts to avoid duplicate exports
 import type { PaymentStatus } from './payment';
@@ -49,6 +49,10 @@ export interface Registration {
   notes?: string;
   status: RegistrationStatus;
   paymentStatus: PaymentStatus;
+  priceAmount?: number;
+  priceCurrency?: string;
+  paid?: boolean;
+  paidAmount?: number;
   groupAssignment?: string;
   reviewedBy?: string;
   reviewedAt?: string;
@@ -100,11 +104,17 @@ export interface RegistrationFilters {
 export interface RegistrationStatistics {
   total: number;
   pending: number;
+  pendingPayment: number;
   approved: number;
   rejected: number;
   withdrawn: number;
   paidCount: number;
   unpaidCount: number;
+}
+
+export interface MarkAsPaidDto {
+  paidAmount?: number;
+  reviewNotes?: string;
 }
 
 export interface AgeGroupRegistrationStatistics {


### PR DESCRIPTION
Implements Issue #88 frontend changes:
- Add `PENDING_PAYMENT` status support in types and UI
- Add `markRegistrationAsPaid` service call
- Update tournament dashboard registration actions
- Update registrations list/detail pages for pending payment state
- Add i18n labels for `PENDING_PAYMENT` in EN/RO

Validated with Playwright flow screenshots.
