### PR TITLE
feat: Tournament format conditional UI for Single/Double Elimination vs Groups

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -335,7 +335,13 @@
       "groupsCount": "Number of Groups",
       "groupsCountHelp": "Number of groups for this category",
       "numberOfMatches": "Guaranteed Matches",
-      "numberOfMatchesHelp": "Minimum matches each team will play"
+      "numberOfMatchesHelp": "Minimum matches each team will play",
+      "guaranteedMatches": "Guaranteed Matches",
+      "guaranteedMatchesHelp": "Minimum matches each team plays via the losers bracket",
+      "advancementOverride": "Advancement Override",
+      "advancementOverrideHelp": "Custom number of teams advancing from losers bracket (leave empty for default)",
+      "singleEliminationInfo": "Single Elimination: Direct knockout – no group stage. Teams are eliminated after one loss.",
+      "doubleEliminationInfo": "Double Elimination: Teams get a second chance through the losers bracket before being eliminated."
     }
   },
   "clubs": {

--- a/src/i18n/locales/ro.json
+++ b/src/i18n/locales/ro.json
@@ -369,7 +369,13 @@
       "groupsCount": "Număr de grupe",
       "groupsCountHelp": "Numărul de grupe pentru această categorie",
       "numberOfMatches": "Meciuri garantate",
-      "numberOfMatchesHelp": "Meciuri minime pe care le va juca fiecare echipă"
+      "numberOfMatchesHelp": "Meciuri minime pe care le va juca fiecare echipă",
+      "guaranteedMatches": "Meciuri garantate",
+      "guaranteedMatchesHelp": "Meciuri minime pe care le joacă fiecare echipă prin bracket-ul pierzătorilor",
+      "advancementOverride": "Avansare personalizată",
+      "advancementOverrideHelp": "Număr personalizat de echipe care avansează din bracket-ul pierzătorilor (lasă gol pentru implicit)",
+      "singleEliminationInfo": "Eliminare simplă: Knockout direct – fără fază de grupe. Echipele sunt eliminate după o singură înfrângere.",
+      "doubleEliminationInfo": "Eliminare dublă: Echipele primesc o a doua șansă prin bracket-ul pierzătorilor înainte de eliminare."
     }
   },
   "clubs": {


### PR DESCRIPTION
## Description
Implements conditional UI rendering in the Age Groups Manager based on tournament format selection.

## Issue
Closes #172

## Changes Made
- **Conditional Rendering**: Hide group configuration fields (Teams Per Group, Number of Groups) when Single or Double Elimination format is selected
- **Double Elimination Configuration**: Show Guaranteed Matches (default: 2) and Advancement Override fields for Double Elimination format
- **Visual Enhancements**:
  - Format badge with color coding (orange for elimination, green for groups)
  - Info banner explaining elimination format behavior
- **State Management**: Automatic field clearing/restoration when switching between format types
- **Translations**: Added 6 new i18n keys for English and Romanian

## Testing
✅ Desktop testing (1440x900 viewport)
✅ Mobile testing (375x812 viewport)
✅ All format transitions verified (Groups+Knockout ↔ Single Elimination ↔ Double Elimination ↔ Round Robin)
✅ Acceptance criteria verified:
- Single/Double Elimination hides group UI
- Double Elimination shows guaranteed matches configuration
- Format badge displays correctly
- Info banners show appropriate messages

## Files Changed
- `src/components/ui/AgeGroupsManager.tsx` - Main component with conditional logic
- `src/i18n/locales/en.json` - English translations
- `src/i18n/locales/ro.json` - Romanian translations

## Screenshots
All test scenarios documented in `notes/issue-172/testing-results-2026-02-16.md`