### PR TITLE
fix: resolve TypeScript build errors in team types

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/main/clubs/[id]/page.tsx
+++ b/src/app/main/clubs/[id]/page.tsx
@@ -192,14 +192,14 @@ export default function ClubDetailPage() {
                   >
                     <div className="flex items-center gap-3">
                       <Avatar
-                        src={team.logo}
+                        src={team.club?.logo || club.logo}
                         alt={team.name}
                         size="md"
                       />
                       <div>
                         <p className="font-medium">{team.name}</p>
                         <p className="text-sm text-gray-500">
-                          {team.ageCategory} • {team.playerCount || 0} {t('common.players')}
+                          {team.ageCategory} • {team.players?.length || 0} {t('common.players')}
                         </p>
                       </div>
                     </div>

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -11,9 +11,9 @@ export interface Player {
 export interface Team {
   id: string;
   name: string;
-  ageCategory: string;
-  birthyear: number;
-  coach: string;
+  ageCategory?: string | null;
+  birthyear?: number | null;
+  coach?: string | null;
   clubId: string;
   club?: {
     id: string;
@@ -28,9 +28,9 @@ export interface Team {
 export interface CreateTeamDto {
   clubId: string;
   name: string;
-  ageCategory: string;
-  birthyear: number;
-  coach: string;
+  ageCategory?: string;
+  birthyear?: number;
+  coach?: string;
   playerIds?: string[];
 }
 


### PR DESCRIPTION
- Make Team fields optional (ageCategory, birthyear, coach) to match nullable backend columns
- Make CreateTeamDto fields optional for flexible team creation
- Fix team logo reference to use club.logo fallback
- Fix playerCount reference to use players.length