### PR TITLE
feat(tournaments): add numberOfFields to create/edit/view pages [#101]

### DIFF
--- a/src/app/dashboard/tournaments/[id]/edit/page.tsx
+++ b/src/app/dashboard/tournaments/[id]/edit/page.tsx
@@ -66,6 +66,7 @@ const tournamentSchema = z.object({
   contactPhone: z.string().optional(),
   status: z.enum(TOURNAMENT_STATUSES),
   isPrivate: z.boolean().optional(),
+  numberOfFields: z.coerce.number().int().min(1).max(100).optional(),
 });
 
 type TournamentFormData = z.infer<typeof tournamentSchema>;
@@ -273,6 +274,7 @@ export default function EditTournamentPage() {
               locationId: ag.locationId,
               locationAddress: ag.locationAddress,
               groupsCount: ag.groupsCount,
+              fieldsCount: ag.fieldsCount,
               teamsPerGroup: ag.teamsPerGroup,
               matchPeriodType: (ag as any).matchPeriodType,
               halfDurationMinutes: (ag as any).halfDurationMinutes,
@@ -305,6 +307,7 @@ export default function EditTournamentPage() {
         contactPhone: data.contactPhone || "",
         status: data.status === "DRAFT" ? "PUBLISHED" : data.status,
         isPrivate: (data as any).isPrivate || false,
+        numberOfFields: (data as any).numberOfFields ?? undefined,
       });
       setSlugTouched(!!data.urlSlug);
     } catch (err: any) {
@@ -358,6 +361,7 @@ export default function EditTournamentPage() {
         }),
         // Include isPrivate field
         isPrivate: data.isPrivate,
+        ...(data.numberOfFields && { numberOfFields: data.numberOfFields }),
         // Only include contactEmail if it's a valid email (not empty string)
         ...(data.contactEmail &&
           data.contactEmail.trim() !== "" && {
@@ -603,6 +607,24 @@ export default function EditTournamentPage() {
                   )}
                 </p>
               )}
+
+              <Input
+                type="number"
+                label={t(
+                  "tournament.numberOfFields",
+                  "Number of Fields / Grounds",
+                )}
+                placeholder="e.g. 4"
+                helperText={t(
+                  "tournament.numberOfFieldsHelp",
+                  "Total playing fields available (parallel games, e.g. 1vs2 on field 1, 3vs4 on field 2)",
+                )}
+                min={1}
+                max={100}
+                step={1}
+                error={errors.numberOfFields?.message}
+                {...register("numberOfFields", { valueAsNumber: true })}
+              />
             </CardContent>
           </Card>
 

--- a/src/app/dashboard/tournaments/create/page.tsx
+++ b/src/app/dashboard/tournaments/create/page.tsx
@@ -50,6 +50,7 @@ const tournamentSchema = z.object({
   rules: z.string().optional(),
   isPrivate: z.boolean().default(false),
   invitationCodeExpirationDays: z.coerce.number().min(1).max(365).optional(),
+  numberOfFields: z.coerce.number().int().min(1).max(100).optional(),
 });
 
 type TournamentFormData = z.infer<typeof tournamentSchema>;
@@ -235,6 +236,7 @@ export default function CreateTournamentPage() {
         ...(data.whatsappGroupLink?.trim() && {
           whatsappGroupLink: data.whatsappGroupLink.trim(),
         }),
+        ...(data.numberOfFields && { numberOfFields: data.numberOfFields }),
         isPrivate: data.isPrivate,
         // Only include rules if provided (as regulationsData)
         ...(data.rules && { regulationsData: { rules: data.rules } }),
@@ -372,6 +374,24 @@ export default function CreateTournamentPage() {
                 )}
                 error={errors.whatsappGroupLink?.message}
                 {...register("whatsappGroupLink")}
+              />
+
+              <Input
+                type="number"
+                label={t(
+                  "tournament.numberOfFields",
+                  "Number of Fields / Grounds",
+                )}
+                placeholder="e.g. 4"
+                helperText={t(
+                  "tournament.numberOfFieldsHelp",
+                  "Total playing fields available (parallel games, e.g. 1vs2 on field 1, 3vs4 on field 2)",
+                )}
+                min={1}
+                max={100}
+                step={1}
+                error={errors.numberOfFields?.message}
+                {...register("numberOfFields", { valueAsNumber: true })}
               />
 
               <div className="flex flex-col sm:flex-row gap-3">

--- a/src/app/main/tournaments/[id]/page.tsx
+++ b/src/app/main/tournaments/[id]/page.tsx
@@ -429,6 +429,12 @@ export default function TournamentDetailPage() {
                   <span className="font-medium">{tournament.numberOfMatches}</span>
                 </div>
               )}
+              {tournament.numberOfFields && (
+                <div className="flex items-center justify-between p-3 bg-white border border-gray-200 rounded-lg">
+                  <span className="text-gray-600">{t('tournament.numberOfFields', 'Number of Fields')}</span>
+                  <span className="font-medium">{tournament.numberOfFields}</span>
+                </div>
+              )}
               <div className="flex items-center justify-between p-3 bg-white border border-gray-200 rounded-lg">
                 <span className="text-gray-600">{t('tournament.teamsRegistered', 'Teams Registered')}</span>
                 <span className="font-medium">{ageGroupCurrentTeams} / {ageGroupMaxTeams}</span>

--- a/src/components/ui/AgeGroupsManager.tsx
+++ b/src/components/ui/AgeGroupsManager.tsx
@@ -94,6 +94,7 @@ export interface AgeGroupFormData {
   locationId?: string;
   locationAddress?: string;
   groupsCount?: number;
+  fieldsCount?: number;
   teamsPerGroup?: number;
   matchPeriodType?: 'ONE_HALF' | 'TWO_HALVES';
   halfDurationMinutes?: number;
@@ -460,6 +461,23 @@ export function AgeGroupsManager({
                           }
                           disabled={disabled}
                           helperText={t('tournaments.ageGroups.groupsCountHelp', 'Auto-calculated: Total teams ÷ Teams per group')}
+                        />
+
+                        {/* Number of Fields - issue #189 */}
+                        <Input
+                          type="number"
+                          label={t('tournaments.ageGroups.fieldsCount', 'Number of Fields')}
+                          value={ageGroup.fieldsCount ?? ''}
+                          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                            handleUpdateAgeGroup(index, {
+                              fieldsCount: e.target.value ? parseInt(e.target.value) : undefined,
+                            })
+                          }
+                          min={1}
+                          max={50}
+                          step={1}
+                          disabled={disabled}
+                          helperText={t('tournaments.ageGroups.fieldsCountHelp', 'Number of playing fields available (games running simultaneously)')}
                         />
 
                         <Select

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -829,6 +829,7 @@
     "maxTeams": "Maximum Teams",
     "numberOfMatches": "Guaranteed Matches",
     "numberOfMatchesHelp": "Minimum matches each team will play",
+    "numberOfFields": "Number of Fields",
     "registrationFee": "Registration Fee",
     "numberOfGroups": "Number of Groups",
     "teamsPerGroup": "Teams per Group",

--- a/src/i18n/locales/ro.json
+++ b/src/i18n/locales/ro.json
@@ -971,6 +971,7 @@
     "minTeams": "Număr minim echipe",
     "numberOfMatches": "Meciuri garantate",
     "numberOfMatchesHelp": "Numărul minim de meciuri pe care le va juca fiecare echipă",
+    "numberOfFields": "Număr de terenuri",
     "registeredTeams": "Echipe înregistrate",
     "noTeamsYet": "Nu există echipe înscrise încă",
     "spotsLeft": "Locuri disponibile",

--- a/src/types/tournament.ts
+++ b/src/types/tournament.ts
@@ -71,6 +71,7 @@ export interface AgeGroup {
   locationAddress?: string;
   participationFee?: number;
   groupsCount?: number;
+  fieldsCount?: number;
   teamsPerGroup?: number;
   matchPeriodType?: "ONE_HALF" | "TWO_HALVES";
   halfDurationMinutes?: number;
@@ -140,6 +141,7 @@ export interface Tournament {
   groupCount?: number;
   teamsPerGroup?: number;
   thirdPlaceMatch?: boolean;
+  numberOfFields?: number;
   regulationsType?: RegulationsType;
   regulationsData?: Record<string, unknown>;
   brochureUrl?: string;
@@ -190,6 +192,7 @@ export interface CreateTournamentDto {
   groupCount?: number;
   teamsPerGroup?: number;
   thirdPlaceMatch?: boolean;
+  numberOfFields?: number;
   regulationsType?: RegulationsType;
   regulationsData?: Record<string, unknown>;
   brochureUrl?: string;


### PR DESCRIPTION
## Summary

Implements the frontend part of issue **#101** — **Add number of fields/grounds to tournament model and endpoints**.

## Changes

### `src/types/tournament.ts`
- Added `numberOfFields?: number` to both `Tournament` and `CreateTournament` interfaces

### `src/app/dashboard/tournaments/create/page.tsx`
- Added `numberOfFields` Zod field (optional, positive integer)
- Added "Number of Fields" input in the tournament details section
- Included in form submit payload

### `src/app/dashboard/tournaments/[id]/edit/page.tsx`
- Added `numberOfFields` Zod field with pre-population from existing tournament data
- Added "Number of Fields" input in the tournament details section
- Included in update payload

### `src/app/main/tournaments/[id]/page.tsx`
- Added "Number of Fields" row in the Tournament Details card (conditionally rendered when value is set)

### `src/components/ui/AgeGroupsManager.tsx`
- Added `fieldsCount` input per age category configuration

### `src/i18n/locales/en.json` & `ro.json`
- Added `tournament.numberOfFields` translation key
  - EN: `"Number of Fields"`
  - RO: `"Număr de terenuri"`

## Screenshots

Full click-based Playwright flow test performed:
- Create form with `numberOfFields=3` ✅
- Public view after creation ✅
- Edit form pre-populated with `numberOfFields=3` ✅  
- Updated to `numberOfFields=5`, saved ✅
- Public view showing "Number of Fields: 5" ✅
- Anonymous user view ✅
- Mobile view (375px) ✅