### PR TITLE
fix(tournaments): display full name and description without truncation [#190]

### DIFF
--- a/src/app/dashboard/tournaments/page.tsx
+++ b/src/app/dashboard/tournaments/page.tsx
@@ -248,7 +248,7 @@ export default function DashboardTournamentsPage() {
                             </div>
                           )}
                           <div className="min-w-0 flex-1">
-                            <Link href={`/dashboard/tournaments/${tournament.id}`} className="font-semibold text-gray-900 hover:text-primary block truncate">
+                            <Link href={`/dashboard/tournaments/${tournament.id}`} className="font-semibold text-gray-900 hover:text-primary block">
                               {tournament.name}
                             </Link>
                             <div className="mt-1">

--- a/src/app/main/tournaments/page.tsx
+++ b/src/app/main/tournaments/page.tsx
@@ -714,7 +714,7 @@ export default function TournamentsPage() {
                     )}
                     <CardContent className="p-4">
                       <div className="flex items-start justify-between gap-2">
-                        <h3 className="font-semibold text-lg line-clamp-1">
+                        <h3 className="font-semibold text-lg">
                           {tournament.name}
                         </h3>
                         {!tournament.bannerImage && (
@@ -729,7 +729,7 @@ export default function TournamentsPage() {
                           </Badge>
                         )}
                       </div>
-                      <p className="text-gray-600 text-sm mt-2 line-clamp-2">
+                      <p className="text-gray-600 text-sm mt-2">
                         {tournament.description}
                       </p>
                       <div className="mt-4 space-y-2">


### PR DESCRIPTION
## Summary

Fixes issue **#190** — "Display tournament name and full description correctly".

## Problem

Tournament names and descriptions were being cut off in listing views due to Tailwind CSS utility classes:

| Location | Element | Class causing truncation |
|---|---|---|
| `src/app/main/tournaments/page.tsx` | Name `<h3>` in public listing cards | `line-clamp-1` |
| `src/app/main/tournaments/page.tsx` | Description `<p>` in public listing cards | `line-clamp-2` |
| `src/app/dashboard/tournaments/page.tsx` | Name `<Link>` in dashboard grid cards | `truncate` |

## Fix

Removed the three truncation classes so names and descriptions render in full.

## Changes

- [src/app/main/tournaments/page.tsx](../blob/feature/issue-190-display-full-tournament-name-description/src/app/main/tournaments/page.tsx) — removed `line-clamp-1` from name `<h3>`, removed `line-clamp-2` from description `<p>`
- [src/app/dashboard/tournaments/page.tsx](../blob/feature/issue-190-display-full-tournament-name-description/src/app/dashboard/tournaments/page.tsx) — removed `truncate` from grid card name link

## Test Results

Playwright flow tested across 6 scenarios:
- ✅ Public listing — desktop (full names + descriptions visible)
- ✅ Public listing — mobile (375px)
- ✅ Dashboard — list view (full names)
- ✅ Dashboard — grid view (names wrap correctly)
- ✅ Dashboard — grid mobile
- ✅ Tournament detail page (description shown in full)