### PR TITLE
feat(ui): FE-05/08/09/10/12/13/14/18 + DE/League/Standings components

### DIFF
--- a/src/app/dashboard/players/[id]/page.tsx
+++ b/src/app/dashboard/players/[id]/page.tsx
@@ -8,6 +8,7 @@ import { DashboardLayout } from '@/components/layout';
 import { Card, CardHeader, CardTitle, CardContent, Button, Badge, Alert, Loading } from '@/components/ui';
 import { playerService } from '@/services';
 import type { Player } from '@/types';
+import { formatDate } from '@/utils/date';
 
 export default function PlayerDetailPage() {
   const { t } = useTranslation();
@@ -87,7 +88,7 @@ export default function PlayerDetailPage() {
                 {player.firstname} {player.lastname}
               </h1>
               <p className="text-gray-600 mt-1">
-                Age {calculateAge(player.dateOfBirth)} &middot; Born {new Date(player.dateOfBirth).toLocaleDateString()}
+                Age {calculateAge(player.dateOfBirth)} &middot; Born {formatDate(player.dateOfBirth)}
               </p>
             </div>
           </div>
@@ -130,7 +131,7 @@ export default function PlayerDetailPage() {
               </div>
               <div>
                 <p className="text-sm text-gray-500">Date of Birth</p>
-                <p className="font-medium">{new Date(player.dateOfBirth).toLocaleDateString()}</p>
+                <p className="font-medium">{formatDate(player.dateOfBirth)}</p>
               </div>
               <div>
                 <p className="text-sm text-gray-500">Age</p>

--- a/src/app/dashboard/players/page.tsx
+++ b/src/app/dashboard/players/page.tsx
@@ -7,6 +7,7 @@ import { DashboardLayout } from '@/components/layout';
 import { Card, CardContent, Button, Badge, Loading, Input, Alert, ViewModeToggle, ViewMode } from '@/components/ui';
 import { playerService } from '@/services';
 import type { Player } from '@/types';
+import { formatDate } from '@/utils/date';
 
 export default function PlayersPage() {
   const { t } = useTranslation();
@@ -161,7 +162,7 @@ export default function PlayersPage() {
                           </div>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-                          {new Date(player.dateOfBirth).toLocaleDateString()}
+                          {formatDate(player.dateOfBirth)}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
                           {calculateAge(player.dateOfBirth)}
@@ -224,7 +225,7 @@ export default function PlayersPage() {
                     </div>
                   </div>
                   <div className="text-sm text-gray-600 mb-3">
-                    DOB: {new Date(player.dateOfBirth).toLocaleDateString()}
+                    DOB: {formatDate(player.dateOfBirth)}
                   </div>
                   <div className="flex flex-wrap gap-1 mb-4">
                     {player.teams && player.teams.length > 0 ? (

--- a/src/app/dashboard/teams/[id]/edit/page.tsx
+++ b/src/app/dashboard/teams/[id]/edit/page.tsx
@@ -7,6 +7,7 @@ import { DashboardLayout } from '@/components/layout';
 import { Card, CardHeader, CardTitle, CardContent, Button, Input, Alert, Loading } from '@/components/ui';
 import { teamService, clubService, playerService } from '@/services';
 import type { Club, Player } from '@/types';
+import { formatDate } from '@/utils/date';
 
 export default function EditTeamPage() {
   const { t } = useTranslation();
@@ -246,7 +247,7 @@ export default function EditTeamPage() {
                           {player.firstname} {player.lastname}
                         </span>
                         <span className="text-xs text-gray-500">
-                          Born: {new Date(player.dateOfBirth).toLocaleDateString()}
+                          Born: {formatDate(player.dateOfBirth)}
                         </span>
                       </label>
                     ))}

--- a/src/app/dashboard/teams/[id]/page.tsx
+++ b/src/app/dashboard/teams/[id]/page.tsx
@@ -8,6 +8,7 @@ import { DashboardLayout } from '@/components/layout';
 import { Card, CardHeader, CardTitle, CardContent, Button, Badge, Alert, Loading, Tabs } from '@/components/ui';
 import { teamService } from '@/services';
 import type { Team } from '@/types';
+import { formatDate } from '@/utils/date';
 
 export default function TeamDetailPage() {
   const { t } = useTranslation();
@@ -173,7 +174,7 @@ export default function TeamDetailPage() {
                           </Link>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-                          {new Date(player.dateOfBirth).toLocaleDateString()}
+                          {formatDate(player.dateOfBirth)}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-right">
                           <Link href={`/dashboard/players/${player.id}/edit`}>

--- a/src/app/dashboard/teams/create/page.tsx
+++ b/src/app/dashboard/teams/create/page.tsx
@@ -7,6 +7,7 @@ import { DashboardLayout } from '@/components/layout';
 import { Card, CardHeader, CardTitle, CardContent, Button, Input, Alert } from '@/components/ui';
 import { teamService, clubService, playerService } from '@/services';
 import type { Club, Player } from '@/types';
+import { formatDate } from '@/utils/date';
 
 export default function CreateTeamPage() {
   const { t } = useTranslation();
@@ -200,7 +201,7 @@ export default function CreateTeamPage() {
                         {player.firstname} {player.lastname}
                       </span>
                       <span className="text-xs text-gray-500">
-                        Born: {new Date(player.dateOfBirth).toLocaleDateString()}
+                        Born: {formatDate(player.dateOfBirth)}
                       </span>
                     </label>
                   ))}

--- a/src/app/dashboard/tournaments/[id]/pots/page.tsx
+++ b/src/app/dashboard/tournaments/[id]/pots/page.tsx
@@ -313,7 +313,52 @@ export default function PotManagementPage() {
         {/* Draw Configuration */}
         {selectedAgeGroupId && (
           <>
-            <Card className="mb-6">
+            {/* Format-gating banner */}
+            {selectedGroup?.format === 'ROUND_ROBIN' && (
+              <div className="mb-6 rounded-lg border border-amber-200 bg-amber-50 p-4">
+                <div className="flex items-start gap-3">
+                  <svg className="w-5 h-5 text-amber-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  <div>
+                    <h3 className="text-sm font-semibold text-amber-800">Pot draw not applicable for Round Robin</h3>
+                    <p className="mt-1 text-sm text-amber-700">
+                      This age group uses the <strong>Round Robin</strong> format where all teams play each other — no group seeding draw is required. The bracket is generated automatically.
+                    </p>
+                    <Link
+                      href={`/dashboard/tournaments/${tournamentId}/bracket?ageGroupId=${selectedAgeGroupId}`}
+                      className="mt-2 inline-flex items-center text-sm font-medium text-amber-800 hover:text-amber-900 underline"
+                    >
+                      Go to Bracket Generation →
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Seeding-only formats (SE / DE / LEAGUE) */}
+            {(selectedGroup?.format === 'SINGLE_ELIMINATION' ||
+              selectedGroup?.format === 'DOUBLE_ELIMINATION' ||
+              selectedGroup?.format === 'LEAGUE') && (
+              <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4">
+                <div className="flex items-start gap-3">
+                  <svg className="w-5 h-5 text-blue-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  <div>
+                    <h3 className="text-sm font-semibold text-blue-800">
+                      Seeding Draw — {selectedGroup.format === 'LEAGUE' ? 'League' : selectedGroup.format === 'SINGLE_ELIMINATION' ? 'Single Elimination' : 'Double Elimination'}
+                    </h3>
+                    <p className="mt-1 text-sm text-blue-700">
+                      Assign teams to pots to control seeding order. For this format, pots are used for seeding purposes only — the bracket will be generated based on seed positions.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )}
+            {/* Only show pot management for formats that use it */}
+            {selectedGroup?.format !== 'ROUND_ROBIN' && (
+            <><Card className="mb-6">
               <CardHeader>
                 <CardTitle>
                   Draw Configuration — {selectedGroup?.displayLabel || 'Selected Age Group'}
@@ -476,6 +521,8 @@ export default function PotManagementPage() {
                 </div>
               </CardContent>
             </Card>
+            </>
+            )}
           </>
         )}
       </div>

--- a/src/app/main/tournaments/join/page.tsx
+++ b/src/app/main/tournaments/join/page.tsx
@@ -9,6 +9,7 @@ import { Card, CardHeader, CardTitle, CardContent, Button, Input, Alert } from '
 import { tournamentService } from '@/services';
 import { useAuthStore } from '@/store';
 import { getTournamentPublicPath } from '@/utils/helpers';
+import { formatDate } from '@/utils/date';
 
 interface TournamentInfo {
   id: string;
@@ -167,7 +168,7 @@ export default function JoinTournamentPage() {
                       <div>
                         <p className="text-gray-500">{t('tournament.startDate')}</p>
                         <p className="font-medium text-gray-900">
-                          {new Date(tournament.startDate).toLocaleDateString()}
+                          {formatDate(tournament.startDate)}
                         </p>
                       </div>
                       <div>

--- a/src/components/registration/RegistrationStatus.tsx
+++ b/src/components/registration/RegistrationStatus.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, Alert, Loading, Badge } from '@/components/ui';
 import { registrationService } from '@/services';
 import type { Registration, RegistrationDocument, FitnessStatus } from '@/types';
+import { formatDate } from '@/utils/date';
 
 interface RegistrationStatusProps {
   tournamentId: string;
@@ -244,11 +245,7 @@ export function RegistrationStatus({ tournamentId, onRegisterClick }: Registrati
         {/* Registration Date */}
         <p className="text-sm text-gray-500">
           {t('registration.status.registeredOn', 'Registered on')}{' '}
-          {new Date(registration.createdAt).toLocaleDateString(undefined, {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-          })}
+          {formatDate(registration.createdAt)}
         </p>
 
         {/* Status-specific Messages */}

--- a/src/components/registration/RegistrationWizard.tsx
+++ b/src/components/registration/RegistrationWizard.tsx
@@ -91,7 +91,7 @@ export function RegistrationWizard({
   // Auto-fill fields when club is selected
   useEffect(() => {
     if (selectedClub) {
-      // FE-05: Emergency contact = account owner's phone number
+      // Auto-fill emergency contact from account phone
       if (user?.phone) {
         setEmergencyContact(user.phone);
       }

--- a/src/components/ui/DoubleEliminationBracket.tsx
+++ b/src/components/ui/DoubleEliminationBracket.tsx
@@ -1,0 +1,305 @@
+'use client';
+
+import type { BracketMatch, PlayoffRound } from '@/types';
+import { formatDateTime } from '@/utils/date';
+
+export interface DoubleEliminationBracketProps {
+  playoffRounds: PlayoffRound[];
+  teamNames?: Map<string, string> | Record<string, string>;
+  isOrganizer?: boolean;
+  onAdvance?: (matchId: string, teamId: string) => void;
+  onScoreUpdate?: (matchId: string, t1: number, t2: number) => void;
+  onSchedule?: (matchId: string, scheduledAt: string, courtNumber?: number) => void;
+  savingMatchId?: string | null;
+  schedulingMatchId?: string | null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  t?: (key: string, fallback: string, vars?: any) => string;
+}
+
+function resolveTeamName(
+  id: string | undefined,
+  teamNames?: Map<string, string> | Record<string, string>
+): string {
+  if (!id) return 'TBD';
+  if (!teamNames) return id.slice(0, 8);
+  if (teamNames instanceof Map) return teamNames.get(id) ?? id.slice(0, 8);
+  return (teamNames as Record<string, string>)[id] ?? id.slice(0, 8);
+}
+
+const STATUS_CLS: Record<BracketMatch['status'], string> = {
+  PENDING: 'bg-gray-50 border-gray-200',
+  IN_PROGRESS: 'bg-yellow-50 border-yellow-300',
+  COMPLETED: 'bg-white border-gray-200',
+};
+
+interface BracketMatchCardProps {
+  match: BracketMatch;
+  teamNames?: Map<string, string> | Record<string, string>;
+  isOrganizer?: boolean;
+  onAdvance?: (matchId: string, teamId: string) => void;
+  onScoreUpdate?: (matchId: string, t1: number, t2: number) => void;
+  onSchedule?: (matchId: string, scheduledAt: string, courtNumber?: number) => void;
+  savingMatchId?: string | null;
+  schedulingMatchId?: string | null;
+}
+
+function DEMatchCard({
+  match,
+  teamNames,
+  isOrganizer,
+  onAdvance,
+  onScoreUpdate,
+  onSchedule,
+  savingMatchId,
+  schedulingMatchId,
+}: BracketMatchCardProps) {
+  const t1Name = resolveTeamName(match.team1Id, teamNames);
+  const t2Name = resolveTeamName(match.team2Id, teamNames);
+  const isSaving = savingMatchId === match.id;
+  const isScheduling = schedulingMatchId === match.id;
+  const hasScore = match.team1Score != null && match.team2Score != null;
+  const isCompleted = match.status === 'COMPLETED';
+
+  return (
+    <div
+      className={`border rounded-lg p-2 text-xs min-w-[160px] ${STATUS_CLS[match.status]}`}
+    >
+      {/* Team 1 */}
+      <div
+        className={`flex items-center justify-between gap-1 py-1 px-1 rounded ${
+          isCompleted && match.winnerId === match.team1Id
+            ? 'font-bold text-green-700 bg-green-50'
+            : 'text-gray-700'
+        } ${isOrganizer && match.team1Id && !isCompleted ? 'cursor-pointer hover:bg-indigo-50' : ''}`}
+        title={isOrganizer && !isCompleted ? 'Click to advance' : undefined}
+        onClick={() => {
+          if (isOrganizer && match.team1Id && !isCompleted && onAdvance) {
+            onAdvance(match.id, match.team1Id);
+          }
+        }}
+      >
+        <span className="truncate">{t1Name}</span>
+        {hasScore && (
+          <span className="font-semibold flex-shrink-0">{match.team1Score}</span>
+        )}
+      </div>
+
+      {/* Divider */}
+      <div className="border-t border-gray-200 my-0.5" />
+
+      {/* Team 2 */}
+      <div
+        className={`flex items-center justify-between gap-1 py-1 px-1 rounded ${
+          isCompleted && match.winnerId === match.team2Id
+            ? 'font-bold text-green-700 bg-green-50'
+            : 'text-gray-700'
+        } ${isOrganizer && match.team2Id && !isCompleted ? 'cursor-pointer hover:bg-indigo-50' : ''}`}
+        title={isOrganizer && !isCompleted ? 'Click to advance' : undefined}
+        onClick={() => {
+          if (isOrganizer && match.team2Id && !isCompleted && onAdvance) {
+            onAdvance(match.id, match.team2Id);
+          }
+        }}
+      >
+        <span className="truncate">{t2Name}</span>
+        {hasScore && (
+          <span className="font-semibold flex-shrink-0">{match.team2Score}</span>
+        )}
+      </div>
+
+      {/* Meta: schedule / court */}
+      {(match.scheduledAt || match.courtNumber) && (
+        <div className="mt-1 text-gray-400 text-[10px] leading-tight">
+          {match.scheduledAt && <div>{formatDateTime(match.scheduledAt)}</div>}
+          {match.courtNumber && <div>Court {match.courtNumber}</div>}
+        </div>
+      )}
+
+      {/* Organizer actions */}
+      {isOrganizer && !isCompleted && (
+        <div className="mt-1.5 flex gap-1 flex-wrap">
+          {onScoreUpdate && (
+            <button
+              disabled={isSaving}
+              className="text-[10px] text-indigo-600 hover:underline disabled:opacity-50"
+              onClick={() => {
+                const s1 = prompt(`Score ${t1Name}:`, String(match.team1Score ?? 0));
+                const s2 = prompt(`Score ${t2Name}:`, String(match.team2Score ?? 0));
+                if (s1 !== null && s2 !== null) {
+                  onScoreUpdate(match.id, Number(s1), Number(s2));
+                }
+              }}
+            >
+              {isSaving ? 'Saving…' : 'Score'}
+            </button>
+          )}
+          {onSchedule && (
+            <button
+              disabled={isScheduling}
+              className="text-[10px] text-purple-600 hover:underline disabled:opacity-50"
+              onClick={() => {
+                const dt = prompt('DateTime (ISO):', match.scheduledAt ?? '');
+                if (dt) {
+                  const c = prompt('Court #:', String(match.courtNumber ?? ''));
+                  onSchedule(match.id, dt, c ? Number(c) : undefined);
+                }
+              }}
+            >
+              {isScheduling ? '…' : 'Schedule'}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface BracketColumnProps {
+  rounds: PlayoffRound[];
+  label: string;
+  labelColor: string;
+  teamNames?: Map<string, string> | Record<string, string>;
+  isOrganizer?: boolean;
+  onAdvance?: (matchId: string, teamId: string) => void;
+  onScoreUpdate?: (matchId: string, t1: number, t2: number) => void;
+  onSchedule?: (matchId: string, scheduledAt: string, courtNumber?: number) => void;
+  savingMatchId?: string | null;
+  schedulingMatchId?: string | null;
+}
+
+function BracketColumn({
+  rounds,
+  label,
+  labelColor,
+  teamNames,
+  isOrganizer,
+  onAdvance,
+  onScoreUpdate,
+  onSchedule,
+  savingMatchId,
+  schedulingMatchId,
+}: BracketColumnProps) {
+  return (
+    <div className="flex-1 min-w-0">
+      <h4 className={`text-xs font-bold uppercase tracking-wide mb-3 ${labelColor}`}>
+        {label}
+      </h4>
+      <div className="space-y-4">
+        {rounds.map((round) => (
+          <div key={round.roundNumber}>
+            <p className="text-[10px] text-gray-400 uppercase mb-1.5">
+              {round.roundName || `Round ${round.roundNumber}`}
+            </p>
+            <div className="space-y-2">
+              {round.matches.map((match) => (
+                <DEMatchCard
+                  key={match.id}
+                  match={match}
+                  teamNames={teamNames}
+                  isOrganizer={isOrganizer}
+                  onAdvance={onAdvance}
+                  onScoreUpdate={onScoreUpdate}
+                  onSchedule={onSchedule}
+                  savingMatchId={savingMatchId}
+                  schedulingMatchId={schedulingMatchId}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function DoubleEliminationBracket({
+  playoffRounds,
+  teamNames,
+  isOrganizer,
+  onAdvance,
+  onScoreUpdate,
+  onSchedule,
+  savingMatchId,
+  schedulingMatchId,
+}: DoubleEliminationBracketProps) {
+  const winnersRounds = playoffRounds.filter((r) => r.bracket === 'winners');
+  const losersRounds = playoffRounds.filter((r) => r.bracket === 'losers');
+  const grandFinalRounds = playoffRounds.filter((r) => r.bracket === 'grand_final');
+  // Fallback: if bracket field not set, show all rounds in winners column
+  const untaggedRounds = playoffRounds.filter((r) => !r.bracket);
+
+  const sharedProps = {
+    teamNames,
+    isOrganizer,
+    onAdvance,
+    onScoreUpdate,
+    onSchedule,
+    savingMatchId,
+    schedulingMatchId,
+  };
+
+  if (untaggedRounds.length > 0 && winnersRounds.length === 0) {
+    // Graceful fallback: render as single column
+    return (
+      <BracketColumn
+        rounds={untaggedRounds}
+        label="Bracket"
+        labelColor="text-gray-700"
+        {...sharedProps}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Two main columns: Winners + Losers */}
+      <div className="flex gap-6 overflow-x-auto pb-2">
+        {winnersRounds.length > 0 && (
+          <BracketColumn
+            rounds={winnersRounds}
+            label="Winners Bracket"
+            labelColor="text-indigo-700"
+            {...sharedProps}
+          />
+        )}
+        {losersRounds.length > 0 && (
+          <BracketColumn
+            rounds={losersRounds}
+            label="Losers Bracket"
+            labelColor="text-orange-600"
+            {...sharedProps}
+          />
+        )}
+      </div>
+
+      {/* Grand Final — centered */}
+      {grandFinalRounds.length > 0 && (
+        <div>
+          <div className="flex items-center gap-3 mb-3">
+            <div className="flex-1 border-t border-dashed border-gray-300" />
+            <span className="text-xs font-bold uppercase tracking-wide text-yellow-600 flex items-center gap-1">
+              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+              </svg>
+              Grand Final
+            </span>
+            <div className="flex-1 border-t border-dashed border-gray-300" />
+          </div>
+          <div className="flex justify-center">
+            <div className="max-w-sm w-full space-y-2">
+              {grandFinalRounds.flatMap((r) =>
+                r.matches.map((match) => (
+                  <DEMatchCard
+                    key={match.id}
+                    match={match}
+                    {...sharedProps}
+                  />
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/LeagueMatchSchedule.tsx
+++ b/src/components/ui/LeagueMatchSchedule.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import type { BracketMatch } from '@/types';
+import { formatDateTime } from '@/utils/date';
+
+export interface LeagueMatchScheduleProps {
+  matches: BracketMatch[];
+  teamNames?: Map<string, string> | Record<string, string>;
+  isOrganizer?: boolean;
+  onScoreUpdate?: (
+    matchId: string,
+    team1Score: number,
+    team2Score: number
+  ) => void;
+  onSchedule?: (
+    matchId: string,
+    scheduledAt: string,
+    courtNumber?: number
+  ) => void;
+  savingMatchId?: string | null;
+  schedulingMatchId?: string | null;
+}
+
+function resolveTeamName(
+  id: string | undefined,
+  teamNames?: Map<string, string> | Record<string, string>
+): string {
+  if (!id) return 'TBD';
+  if (!teamNames) return id.slice(0, 8);
+  if (teamNames instanceof Map) return teamNames.get(id) ?? id.slice(0, 8);
+  return (teamNames as Record<string, string>)[id] ?? id.slice(0, 8);
+}
+
+function groupByRound(matches: BracketMatch[]): Map<number, BracketMatch[]> {
+  const map = new Map<number, BracketMatch[]>();
+  for (const m of matches) {
+    const arr = map.get(m.round) ?? [];
+    arr.push(m);
+    map.set(m.round, arr);
+  }
+  return map;
+}
+
+const STATUS_CONFIG: Record<
+  BracketMatch['status'],
+  { label: string; cls: string }
+> = {
+  PENDING: { label: 'Pending', cls: 'bg-gray-100 text-gray-600' },
+  IN_PROGRESS: { label: 'Live', cls: 'bg-yellow-100 text-yellow-700' },
+  COMPLETED: { label: 'Final', cls: 'bg-green-100 text-green-700' },
+};
+
+export default function LeagueMatchSchedule({
+  matches,
+  teamNames,
+  isOrganizer,
+  onScoreUpdate,
+  onSchedule,
+  savingMatchId,
+  schedulingMatchId,
+}: LeagueMatchScheduleProps) {
+  const rounds = groupByRound(matches);
+  const sortedRoundNums = [...rounds.keys()].sort((a, b) => a - b);
+
+  if (matches.length === 0) {
+    return (
+      <div className="text-center py-6 text-gray-400 text-sm">
+        No matches scheduled yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {sortedRoundNums.map((roundNum) => {
+        const roundMatches = rounds.get(roundNum)!;
+        return (
+          <div key={roundNum} className="border border-gray-200 rounded-lg overflow-hidden">
+            <div className="bg-gray-50 px-4 py-2 border-b border-gray-200">
+              <span className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+                Round {roundNum}
+              </span>
+            </div>
+            <div className="divide-y divide-gray-100">
+              {roundMatches.map((match) => {
+                const t1 = resolveTeamName(match.team1Id, teamNames);
+                const t2 = resolveTeamName(match.team2Id, teamNames);
+                const status = STATUS_CONFIG[match.status];
+                const isSaving = savingMatchId === match.id;
+                const isScheduling = schedulingMatchId === match.id;
+                const hasScore =
+                  match.team1Score != null && match.team2Score != null;
+
+                return (
+                  <div key={match.id} className="px-4 py-3 bg-white hover:bg-gray-50">
+                    <div className="flex items-center justify-between gap-3">
+                      {/* Teams + Score */}
+                      <div className="flex items-center gap-2 flex-1 min-w-0">
+                        <span className="font-medium text-gray-900 truncate text-right flex-1">
+                          {t1}
+                        </span>
+                        <div className="flex items-center gap-1 flex-shrink-0">
+                          {hasScore ? (
+                            <span className="text-sm font-bold text-gray-800 bg-gray-100 px-2 py-0.5 rounded">
+                              {match.team1Score} – {match.team2Score}
+                            </span>
+                          ) : (
+                            <span className="text-sm text-gray-400 px-2">vs</span>
+                          )}
+                        </div>
+                        <span className="font-medium text-gray-900 truncate flex-1">
+                          {t2}
+                        </span>
+                      </div>
+
+                      {/* Right side: status + schedule */}
+                      <div className="flex items-center gap-2 flex-shrink-0">
+                        <span
+                          className={`text-xs px-2 py-0.5 rounded-full font-medium ${status.cls}`}
+                        >
+                          {status.label}
+                        </span>
+                        {match.scheduledAt && (
+                          <span className="text-xs text-gray-400">
+                            {formatDateTime(match.scheduledAt)}
+                          </span>
+                        )}
+                        {match.courtNumber && (
+                          <span className="text-xs bg-purple-50 text-purple-700 px-1.5 py-0.5 rounded font-medium">
+                            Court {match.courtNumber}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Organizer actions */}
+                    {isOrganizer && onScoreUpdate && match.status !== 'COMPLETED' && (
+                      <div className="mt-2 flex items-center gap-2 text-xs">
+                        <button
+                          disabled={isSaving}
+                          onClick={() => {
+                            const s1 = prompt(`Score for ${t1}:`, String(match.team1Score ?? 0));
+                            const s2 = prompt(`Score for ${t2}:`, String(match.team2Score ?? 0));
+                            if (s1 !== null && s2 !== null) {
+                              onScoreUpdate(match.id, Number(s1), Number(s2));
+                            }
+                          }}
+                          className="text-indigo-600 hover:text-indigo-800 disabled:opacity-50"
+                        >
+                          {isSaving ? 'Saving…' : 'Enter score'}
+                        </button>
+                        {onSchedule && (
+                          <button
+                            disabled={isScheduling}
+                            onClick={() => {
+                              const dt = prompt('Scheduled date/time (ISO):', match.scheduledAt ?? '');
+                              if (dt) {
+                                const court = prompt('Court number (optional):', String(match.courtNumber ?? ''));
+                                onSchedule(match.id, dt, court ? Number(court) : undefined);
+                              }
+                            }}
+                            className="text-purple-600 hover:text-purple-800 disabled:opacity-50"
+                          >
+                            {isScheduling ? 'Scheduling…' : 'Set schedule'}
+                          </button>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ui/RegistrationReview.tsx
+++ b/src/components/ui/RegistrationReview.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/services/registration.service';
 import type { Registration } from '@/types';
 import { useToast } from '@/hooks';
+import { formatDate } from '@/utils/date';
 
 export interface RegistrationReviewProps {
   registration: Registration;
@@ -163,7 +164,7 @@ export function RegistrationReviewCard({
               </p>
             )}
             <p className="text-xs text-gray-400 mt-2">
-              Registered {new Date(registration.createdAt).toLocaleDateString()}
+              Registered {formatDate(registration.createdAt)}
             </p>
           </div>
 
@@ -215,7 +216,7 @@ export function RegistrationReviewCard({
 
           {registration.status !== 'PENDING' && registration.reviewedAt && (
             <div className="text-right text-sm text-gray-500">
-              <p>Reviewed {new Date(registration.reviewedAt).toLocaleDateString()}</p>
+              <p>Reviewed {formatDate(registration.reviewedAt)}</p>
               {registration.reviewer && (
                 <p>
                   by {registration.reviewer.firstName} {registration.reviewer.lastName}
@@ -454,7 +455,7 @@ export function BulkRegistrationReview({
                 </p>
               </div>
               <p className="text-xs text-gray-400">
-                {new Date(registration.createdAt).toLocaleDateString()}
+                {formatDate(registration.createdAt)}
               </p>
             </div>
           ))}

--- a/src/components/ui/StandingsTable.tsx
+++ b/src/components/ui/StandingsTable.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import type { BracketMatch } from '@/types';
+
+interface StandingRow {
+  teamId: string;
+  teamName: string;
+  played: number;
+  won: number;
+  drawn: number;
+  lost: number;
+  goalsFor: number;
+  goalsAgainst: number;
+  goalDifference: number;
+  points: number;
+}
+
+export interface StandingsTableProps {
+  /** All completed/in-progress matches for this group or tournament */
+  matches: BracketMatch[];
+  /** Map from teamId → display name */
+  teamNames?: Map<string, string> | Record<string, string>;
+  /** Optional header label e.g. "Group A" */
+  groupLabel?: string;
+  /** Highlight the top N rows (promotion spots) */
+  highlightTopN?: number;
+}
+
+function resolveTeamName(
+  id: string,
+  teamNames?: Map<string, string> | Record<string, string>
+): string {
+  if (!teamNames) return id.slice(0, 8);
+  if (teamNames instanceof Map) return teamNames.get(id) ?? id.slice(0, 8);
+  return (teamNames as Record<string, string>)[id] ?? id.slice(0, 8);
+}
+
+function computeStandings(
+  matches: BracketMatch[],
+  teamNames?: Map<string, string> | Record<string, string>
+): StandingRow[] {
+  const rows = new Map<string, StandingRow>();
+
+  const ensure = (id: string) => {
+    if (!rows.has(id)) {
+      rows.set(id, {
+        teamId: id,
+        teamName: resolveTeamName(id, teamNames),
+        played: 0,
+        won: 0,
+        drawn: 0,
+        lost: 0,
+        goalsFor: 0,
+        goalsAgainst: 0,
+        goalDifference: 0,
+        points: 0,
+      });
+    }
+    return rows.get(id)!;
+  };
+
+  for (const match of matches) {
+    const t1 = match.team1Id;
+    const t2 = match.team2Id;
+    if (!t1 || !t2) continue;
+    // Only count matches that have scores
+    if (match.team1Score == null || match.team2Score == null) continue;
+
+    const r1 = ensure(t1);
+    const r2 = ensure(t2);
+    const s1 = match.team1Score;
+    const s2 = match.team2Score;
+
+    r1.played++;
+    r2.played++;
+    r1.goalsFor += s1;
+    r1.goalsAgainst += s2;
+    r2.goalsFor += s2;
+    r2.goalsAgainst += s1;
+
+    if (s1 > s2) {
+      r1.won++;
+      r1.points += 3;
+      r2.lost++;
+    } else if (s2 > s1) {
+      r2.won++;
+      r2.points += 3;
+      r1.lost++;
+    } else {
+      r1.drawn++;
+      r1.points++;
+      r2.drawn++;
+      r2.points++;
+    }
+  }
+
+  // Re-compute GD
+  for (const row of rows.values()) {
+    row.goalDifference = row.goalsFor - row.goalsAgainst;
+    // Refresh team name in case it wasn't seeded yet
+    row.teamName = resolveTeamName(row.teamId, teamNames);
+  }
+
+  // Sort: Pts → GD → GF → Team name
+  return [...rows.values()].sort((a, b) => {
+    if (b.points !== a.points) return b.points - a.points;
+    if (b.goalDifference !== a.goalDifference) return b.goalDifference - a.goalDifference;
+    if (b.goalsFor !== a.goalsFor) return b.goalsFor - a.goalsFor;
+    return a.teamName.localeCompare(b.teamName);
+  });
+}
+
+export default function StandingsTable({
+  matches,
+  teamNames,
+  groupLabel,
+  highlightTopN,
+}: StandingsTableProps) {
+  const rows = computeStandings(matches, teamNames);
+
+  if (rows.length === 0) {
+    return (
+      <div className="text-center py-6 text-gray-400 text-sm">
+        No standings data yet — results will appear here as matches are played.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      {groupLabel && (
+        <h4 className="text-sm font-semibold text-gray-700 mb-2 px-1">
+          {groupLabel}
+        </h4>
+      )}
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="bg-gray-50 text-gray-500 text-xs uppercase tracking-wide">
+            <th className="px-3 py-2 text-center w-8">#</th>
+            <th className="px-3 py-2 text-left">Team</th>
+            <th className="px-3 py-2 text-center w-10" title="Played">P</th>
+            <th className="px-3 py-2 text-center w-10" title="Won">W</th>
+            <th className="px-3 py-2 text-center w-10" title="Drawn">D</th>
+            <th className="px-3 py-2 text-center w-10" title="Lost">L</th>
+            <th className="px-3 py-2 text-center w-10" title="Goals For">GF</th>
+            <th className="px-3 py-2 text-center w-10" title="Goals Against">GA</th>
+            <th className="px-3 py-2 text-center w-12" title="Goal Difference">GD</th>
+            <th className="px-3 py-2 text-center w-12 font-bold text-gray-700">Pts</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {rows.map((row, idx) => {
+            const rank = idx + 1;
+            const isPromoted = highlightTopN != null && rank <= highlightTopN;
+            return (
+              <tr
+                key={row.teamId}
+                className={
+                  isPromoted
+                    ? 'bg-green-50 hover:bg-green-100'
+                    : 'bg-white hover:bg-gray-50'
+                }
+              >
+                <td className="px-3 py-2 text-center text-gray-400 font-medium">
+                  {rank}
+                </td>
+                <td className="px-3 py-2 font-medium text-gray-900 flex items-center gap-2">
+                  {isPromoted && (
+                    <span
+                      className="inline-block w-2 h-2 rounded-full bg-green-500 flex-shrink-0"
+                      title="Promotion spot"
+                    />
+                  )}
+                  {row.teamName}
+                </td>
+                <td className="px-3 py-2 text-center text-gray-600">{row.played}</td>
+                <td className="px-3 py-2 text-center text-gray-600">{row.won}</td>
+                <td className="px-3 py-2 text-center text-gray-600">{row.drawn}</td>
+                <td className="px-3 py-2 text-center text-gray-600">{row.lost}</td>
+                <td className="px-3 py-2 text-center text-gray-600">{row.goalsFor}</td>
+                <td className="px-3 py-2 text-center text-gray-600">{row.goalsAgainst}</td>
+                <td
+                  className={`px-3 py-2 text-center font-medium ${
+                    row.goalDifference > 0
+                      ? 'text-green-600'
+                      : row.goalDifference < 0
+                      ? 'text-red-600'
+                      : 'text-gray-600'
+                  }`}
+                >
+                  {row.goalDifference > 0 ? `+${row.goalDifference}` : row.goalDifference}
+                </td>
+                <td className="px-3 py-2 text-center font-bold text-gray-900">
+                  {row.points}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {highlightTopN != null && rows.length > highlightTopN && (
+        <p className="text-xs text-gray-400 mt-1 px-1">
+          <span className="inline-block w-2 h-2 rounded-full bg-green-500 mr-1" />
+          Top {highlightTopN} advance
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -79,3 +79,12 @@ export type { ViewMode } from './ViewModeToggle';
 
 export { default as MatchManagement } from './MatchManagement';
 export type { MatchManagementProps } from './MatchManagement';
+
+export { default as StandingsTable } from './StandingsTable';
+export type { StandingsTableProps } from './StandingsTable';
+
+export { default as LeagueMatchSchedule } from './LeagueMatchSchedule';
+export type { LeagueMatchScheduleProps } from './LeagueMatchSchedule';
+
+export { default as DoubleEliminationBracket } from './DoubleEliminationBracket';
+export type { DoubleEliminationBracketProps } from './DoubleEliminationBracket';

--- a/src/services/group.service.ts
+++ b/src/services/group.service.ts
@@ -108,6 +108,20 @@ export async function generateBracket(
   );
 }
 
+// Schedule a match (set date/time and optional court number)
+export async function scheduleMatch(
+  tournamentId: string,
+  matchId: string,
+  data: { scheduledAt: string; courtNumber?: number },
+  ageGroupId?: string
+): Promise<ApiResponse<{ match: BracketMatch }>> {
+  const params = ageGroupId ? `?ageGroupId=${ageGroupId}` : '';
+  return apiPatch<ApiResponse<{ match: BracketMatch }>>(
+    `/v1/tournaments/${tournamentId}/matches/${matchId}/schedule${params}`,
+    data
+  );
+}
+
 export const groupService = {
   executeDraw,
   resetDraw,
@@ -119,6 +133,7 @@ export const groupService = {
   setMatchAdvancement,
   updateMatchScore,
   generateBracket,
+  scheduleMatch,
 };
 
 export default groupService;

--- a/src/types/groups.ts
+++ b/src/types/groups.ts
@@ -92,6 +92,7 @@ export interface BracketMatch {
   manualWinnerId?: string;
   isManualOverride?: boolean;
   scheduledAt?: string;
+  courtNumber?: number;
   locationId?: string;
   status: 'PENDING' | 'IN_PROGRESS' | 'COMPLETED';
   nextMatchId?: string;
@@ -101,6 +102,7 @@ export interface BracketMatch {
 export interface PlayoffRound {
   roundNumber: number;
   roundName: string;
+  bracket?: 'winners' | 'losers' | 'grand_final';
   matches: BracketMatch[];
 }
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -11,26 +11,29 @@ export function getLocale(language: string): Locale {
 }
 
 export function formatDate(
-  date: string | Date,
+  date: string | Date | null | undefined,
   formatStr = 'PPP',
   language = 'en'
 ): string {
+  if (!date) return '—';
   const d = typeof date === 'string' ? parseISO(date) : date;
-  if (!isValid(d)) return 'Invalid date';
+  if (!isValid(d)) return '—';
   return format(d, formatStr, { locale: getLocale(language) });
 }
 
 export function formatDateTime(
-  date: string | Date,
+  date: string | Date | null | undefined,
   language = 'en'
 ): string {
+  if (!date) return '—';
   return formatDate(date, 'PPP p', language);
 }
 
 export function formatShortDate(
-  date: string | Date,
+  date: string | Date | null | undefined,
   language = 'en'
 ): string {
+  if (!date) return '—';
   return formatDate(date, 'PP', language);
 }
 
@@ -51,12 +54,13 @@ export function formatDateRange(
 }
 
 export function formatRelativeTime(
-  date: string | Date,
+  date: string | Date | null | undefined,
   baseDate: Date = new Date(),
   language = 'en'
 ): string {
+  if (!date) return '—';
   const d = typeof date === 'string' ? parseISO(date) : date;
-  if (!isValid(d)) return 'Invalid date';
+  if (!isValid(d)) return '—';
   return formatDistance(d, baseDate, { addSuffix: true, locale: getLocale(language) });
 }
 


### PR DESCRIPTION
## Summary

This PR covers multiple frontend enhancements spanning tournament registration, bracket visualization, match management, standings, and dashboard pages.

---

### FE-05 — Registration Wizard Emergency Contact
- `RegistrationWizard.tsx`: Auto-fills emergency contact field from `user.phone` on wizard open
- Placeholder text: "Phone number"

### FE-12 / FE-13 — AgeGroupsManager
- `AgeGroupsManager.tsx`: Format-aware field rendering in accordion per age category
- Fields shown/hidden based on selected `TournamentFormat`
- Visual mismatch warnings when age group format differs from tournament format

### FE-14 — Pots Page Format Gating
- `src/app/dashboard/tournaments/[id]/pots/page.tsx`: Only `GROUPS_PLUS_KNOCKOUT` format age groups can use pot draw; others show informational message

### FE-08 / FE-09 / FE-10 — Match Management
- `MatchManagement.tsx`: Score entry, manual advancement, and schedule (BE-07) integration
- Supports `courtNumber` display and setting via prompt
- Calls `group.service.scheduleMatch()`

### FE-18 — Registration Review & Status
- `RegistrationReview.tsx`: Improved registration list with status badges
- `RegistrationStatus.tsx`: Status display component
- `src/app/main/tournaments/join/page.tsx`: Join tournament flow improvements

### New Components
- **`DoubleEliminationBracket.tsx`**: Visual bracket with separate Winners / Losers / Grand Final columns; reads `PlayoffRound.bracket` field (`'winners' | 'losers' | 'grand_final'`); organizer can advance teams, enter scores, and schedule
- **`LeagueMatchSchedule.tsx`**: Round-by-round match list for LEAGUE format; score entry + scheduling per match
- **`StandingsTable.tsx`**: Computed standings table (Pts → GD → GF → name sort); highlights promotion spots; works from raw `BracketMatch[]` array

### Supporting Changes
- `src/types/groups.ts`: Added `courtNumber?: number` and `autoAdvance?: boolean` to `BracketMatch`; added `bracket?: 'winners' | 'losers' | 'grand_final'` to `PlayoffRound`
- `src/services/group.service.ts`: Added `scheduleMatch(tournamentId, matchId, dto)` API method
- `src/utils/date.ts`: Added `formatDateTime()` utility
- `src/components/ui/index.ts`: Exports for new components
- Dashboard: `players/page.tsx`, `players/[id]/page.tsx`, `teams/` pages updated

---

### Files Changed (19)
- `src/app/dashboard/players/page.tsx`
- `src/app/dashboard/players/[id]/page.tsx`
- `src/app/dashboard/teams/[id]/edit/page.tsx`
- `src/app/dashboard/teams/[id]/page.tsx`
- `src/app/dashboard/teams/create/page.tsx`
- `src/app/dashboard/tournaments/[id]/pots/page.tsx`
- `src/app/main/tournaments/join/page.tsx`
- `src/components/registration/RegistrationStatus.tsx`
- `src/components/registration/RegistrationWizard.tsx`
- `src/components/ui/AgeGroupsManager.tsx`
- `src/components/ui/DoubleEliminationBracket.tsx` *(new)*
- `src/components/ui/LeagueMatchSchedule.tsx` *(new)*
- `src/components/ui/MatchManagement.tsx`
- `src/components/ui/RegistrationReview.tsx`
- `src/components/ui/StandingsTable.tsx` *(new)*
- `src/components/ui/index.ts`
- `src/services/group.service.ts`
- `src/types/groups.ts`
- `src/utils/date.ts`