### PR TITLE
feat(matches): group tiebreak UI & fix parallel loading flash

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/ui/MatchManagement.tsx
+++ b/src/components/ui/MatchManagement.tsx
@@ -48,16 +48,31 @@ export default function MatchManagement({
       setError(null);
       const response = await groupService.getMatches(tournamentId, ageGroupId);
       const data = response?.data || response;
-      setMatchData(data as MatchesResponse);
+      const matchesData = data as MatchesResponse;
+      setMatchData(matchesData);
 
       // Build teams map
       const teamMap = new Map<string, TeamInfo>();
-      if ((data as MatchesResponse)?.teams) {
-        (data as MatchesResponse).teams.forEach((team) => {
+      if (matchesData?.teams) {
+        matchesData.teams.forEach((team) => {
           teamMap.set(team.id, team);
         });
       }
       setTeams(teamMap);
+
+      // Fetch groups in parallel when bracket type requires them — keeps both
+      // data sets ready before loading is cleared, preventing a flash of the
+      // combined standings table before per-group tables appear.
+      const bt = matchesData?.bracketType;
+      if (bt === 'GROUPS_PLUS_KNOCKOUT' || bt === 'GROUPS_ONLY') {
+        try {
+          const groupsRes = await groupService.getGroups(tournamentId);
+          const groupsData = (groupsRes as any)?.data ?? groupsRes ?? [];
+          setGroups(Array.isArray(groupsData) ? groupsData : []);
+        } catch {
+          setGroups([]);
+        }
+      }
     } catch (err: any) {
       console.error('Failed to load matches:', err);
       setError(
@@ -71,19 +86,6 @@ export default function MatchManagement({
   useEffect(() => {
     fetchMatches();
   }, [fetchMatches]);
-
-  // Fetch group assignments for GROUPS_PLUS_KNOCKOUT / GROUPS_ONLY tournaments
-  useEffect(() => {
-    const bt = matchData?.bracketType;
-    if (bt === 'GROUPS_PLUS_KNOCKOUT' || bt === 'GROUPS_ONLY') {
-      groupService.getGroups(tournamentId)
-        .then((res) => {
-          const data = (res as any)?.data ?? res ?? [];
-          setGroups(Array.isArray(data) ? data : []);
-        })
-        .catch(() => setGroups([]));
-    }
-  }, [tournamentId, matchData?.bracketType]);
 
   const getTeamName = (teamId?: string): string => {
     if (!teamId) return t('matches.tbd', 'TBD');
@@ -177,6 +179,30 @@ export default function MatchManagement({
       );
     } finally {
       setSchedulingMatchId(null);
+    }
+  };
+
+  const handleTiebreakerSet = async (groupId: string, order: string[]) => {
+    try {
+      setError(null);
+      await groupService.setGroupTiebreak(tournamentId, groupId, order, ageGroupId);
+      // Re-fetch groups (tieBreakOrder updated) and matches (bracket may have been re-seeded)
+      await Promise.all([
+        groupService.getGroups(tournamentId).then((res) => {
+          const data = (res as any)?.data ?? res ?? [];
+          setGroups(Array.isArray(data) ? data : []);
+        }),
+        fetchMatches(),
+      ]);
+      setSuccessMessage(t('matches.tiebreakSaved', 'Tiebreak order saved!'));
+      setTimeout(() => setSuccessMessage(null), 3000);
+    } catch (err: any) {
+      console.error('Failed to save tiebreak:', err);
+      setError(
+        err?.response?.data?.error?.message ||
+          err?.response?.data?.message ||
+          t('matches.tiebreakError', 'Failed to save tiebreak order.')
+      );
     }
   };
 
@@ -486,7 +512,10 @@ export default function MatchManagement({
                     <StandingsTable
                       matches={groupMatches}
                       teamNames={groupTeamNames}
-                      highlightTopN={2}
+                      highlightTopN={matchData?.advancingTeamsPerGroup ?? 2}
+                      canEdit={isOrganizer}
+                      tiebreakOrder={group.tieBreakOrder ?? undefined}
+                      onTiebreakerSet={(order) => handleTiebreakerSet(group.id, order)}
                     />
                     {/* Matches for this group */}
                     {groupMatches.length > 0 && (

--- a/src/components/ui/StandingsTable.tsx
+++ b/src/components/ui/StandingsTable.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import type { BracketMatch } from '@/types';
 
 interface StandingRow {
@@ -24,6 +25,12 @@ export interface StandingsTableProps {
   groupLabel?: string;
   /** Highlight the top N rows (promotion spots) */
   highlightTopN?: number;
+  /** If true, show tiebreak controls when a tie is detected and all matches are done */
+  canEdit?: boolean;
+  /** Current persisted tiebreak order (teamIds in rank order, 1st first) */
+  tiebreakOrder?: string[];
+  /** Called with the new ordered teamIds when organizer resolves a tie */
+  onTiebreakerSet?: (order: string[]) => void;
 }
 
 function resolveTeamName(
@@ -125,13 +132,86 @@ function computeStandings(
   });
 }
 
+/** Returns groups of consecutive rows that are exactly equal on pts/GD/GF */
+function findTiedGroups(rows: StandingRow[]): StandingRow[][] {
+  const groups: StandingRow[][] = [];
+  let i = 0;
+  while (i < rows.length) {
+    const cur = rows[i];
+    let j = i + 1;
+    while (
+      j < rows.length &&
+      rows[j].points === cur.points &&
+      rows[j].goalDifference === cur.goalDifference &&
+      rows[j].goalsFor === cur.goalsFor
+    ) {
+      j++;
+    }
+    if (j - i > 1) groups.push(rows.slice(i, j));
+    i = j;
+  }
+  return groups;
+}
+
 export default function StandingsTable({
   matches,
   teamNames,
   groupLabel,
   highlightTopN,
+  canEdit = false,
+  tiebreakOrder,
+  onTiebreakerSet,
 }: StandingsTableProps) {
+  const [saving, setSaving] = useState(false);
+
   const rows = computeStandings(matches, teamNames);
+
+  // Only show tiebreak UI when all matches in the group have been played
+  const allMatchesDone =
+    matches.length > 0 &&
+    matches.every(
+      (m) => m.status === 'COMPLETED' || (m.team1Score != null && m.team2Score != null)
+    );
+
+  // Find tied groups that overlap with advancing spots (or affect seeding within them)
+  const tiedGroups = allMatchesDone ? findTiedGroups(rows) : [];
+  // Only care about ties that touch the highlightTopN boundary or are within advancing spots
+  const relevantTiedGroups =
+    highlightTopN != null
+      ? tiedGroups.filter((g) => {
+          const startIdx = rows.indexOf(g[0]);
+          const endIdx = rows.indexOf(g[g.length - 1]);
+          // Tie overlaps the boundary or is fully within advancing spots
+          return startIdx < highlightTopN;
+        })
+      : tiedGroups;
+
+  const hasTie = canEdit && relevantTiedGroups.length > 0;
+
+  const handlePickWinner = async (tiedTeamIds: string[], pickedFirst: string) => {
+    if (!onTiebreakerSet) return;
+    // Build full order: put pickedFirst at the top, then the rest in their current order
+    const rest = tiedTeamIds.filter((id) => id !== pickedFirst);
+    // Compose the full tiebreak array: for all rows, place tied ones in new order
+    const fullOrder: string[] = [];
+    for (const row of rows) {
+      if (tiedTeamIds.includes(row.teamId)) {
+        if (row.teamId === pickedFirst && !fullOrder.includes(pickedFirst)) {
+          fullOrder.push(pickedFirst);
+          rest.forEach((id) => fullOrder.push(id));
+        }
+        // skip — already pushed via the block above
+      } else {
+        fullOrder.push(row.teamId);
+      }
+    }
+    setSaving(true);
+    try {
+      await onTiebreakerSet(fullOrder);
+    } finally {
+      setSaving(false);
+    }
+  };
 
   if (rows.length === 0) {
     return (
@@ -142,7 +222,7 @@ export default function StandingsTable({
   }
 
   return (
-    <div className="overflow-x-auto">
+    <div className="overflow-x-auto space-y-3">
       {groupLabel && (
         <h4 className="text-sm font-semibold text-gray-700 mb-2 px-1">
           {groupLabel}
@@ -167,6 +247,15 @@ export default function StandingsTable({
           {rows.map((row, idx) => {
             const rank = idx + 1;
             const isPromoted = highlightTopN != null && rank <= highlightTopN;
+            // Is this row part of a relevant tie?
+            const isTied = relevantTiedGroups.some((g) =>
+              g.some((r) => r.teamId === row.teamId)
+            );
+            // Is this team picked first in the current tiebreakOrder?
+            const isTiebreakWinner =
+              tiebreakOrder && tiebreakOrder.length > 0
+                ? tiebreakOrder[0] === row.teamId
+                : false;
             return (
               <tr
                 key={row.teamId}
@@ -176,8 +265,13 @@ export default function StandingsTable({
                     : 'bg-white hover:bg-gray-50'
                 }
               >
-                <td className="px-3 py-2 text-center text-gray-400 font-medium">
+                <td className="px-3 py-2 text-center text-gray-400 font-medium relative">
                   {rank}
+                  {isTied && !isTiebreakWinner && (
+                    <span className="absolute top-1 right-0.5 text-amber-400 text-xs" title="Tie">
+                      ⚠
+                    </span>
+                  )}
                 </td>
                 <td className="px-3 py-2 font-medium text-gray-900 flex items-center gap-2">
                   {isPromoted && (
@@ -187,6 +281,9 @@ export default function StandingsTable({
                     />
                   )}
                   {row.teamName}
+                  {isTiebreakWinner && (
+                    <span className="text-xs text-amber-600 font-normal">(tiebreak winner)</span>
+                  )}
                 </td>
                 <td className="px-3 py-2 text-center text-gray-600">{row.played}</td>
                 <td className="px-3 py-2 text-center text-gray-600">{row.won}</td>
@@ -213,12 +310,55 @@ export default function StandingsTable({
           })}
         </tbody>
       </table>
+
       {highlightTopN != null && rows.length > highlightTopN && (
         <p className="text-xs text-gray-400 mt-1 px-1">
           <span className="inline-block w-2 h-2 rounded-full bg-green-500 mr-1" />
           Top {highlightTopN} advance
         </p>
       )}
+
+      {/* Tiebreak picker — shown to organizer when teams are perfectly tied */}
+      {hasTie &&
+        relevantTiedGroups.map((tiedGroup, gi) => {
+          const tiedIds = tiedGroup.map((r) => r.teamId);
+          const startRank = rows.indexOf(tiedGroup[0]) + 1;
+          return (
+            <div
+              key={gi}
+              className="rounded-lg border border-amber-300 bg-amber-50 p-3"
+            >
+              <p className="text-xs font-semibold text-amber-800 mb-2">
+                ⚠ Teams tied at position {startRank}
+                {tiedGroup.length > 1 ? `–${startRank + tiedGroup.length - 1}` : ''} — select who finishes 1st:
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {tiedGroup.map((row) => {
+                  const isCurrentWinner =
+                    tiebreakOrder && tiebreakOrder[0] === row.teamId;
+                  return (
+                    <button
+                      key={row.teamId}
+                      disabled={saving}
+                      onClick={() => handlePickWinner(tiedIds, row.teamId)}
+                      className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all disabled:opacity-50 ${
+                        isCurrentWinner
+                          ? 'bg-[#1e3a5f] text-white ring-2 ring-[#1e3a5f]'
+                          : 'bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 hover:border-amber-400'
+                      }`}
+                    >
+                      {row.teamName}
+                      {isCurrentWinner && ' ✓'}
+                    </button>
+                  );
+                })}
+              </div>
+              {saving && (
+                <p className="text-xs text-amber-600 mt-2">Saving tiebreak…</p>
+              )}
+            </div>
+          );
+        })}
     </div>
   );
 }

--- a/src/services/group.service.ts
+++ b/src/services/group.service.ts
@@ -122,6 +122,20 @@ export async function scheduleMatch(
   );
 }
 
+// Set manual tiebreak order for a group (organizer only)
+export async function setGroupTiebreak(
+  tournamentId: string,
+  groupId: string,
+  order: string[],
+  ageGroupId?: string
+): Promise<ApiResponse<{ success: boolean; bracketUpdated: boolean }>> {
+  const params = ageGroupId ? `?ageGroupId=${ageGroupId}` : '';
+  return apiPatch<ApiResponse<{ success: boolean; bracketUpdated: boolean }>>(
+    `/v1/tournaments/${tournamentId}/groups/${groupId}/tiebreak${params}`,
+    { order }
+  );
+}
+
 export const groupService = {
   executeDraw,
   resetDraw,
@@ -134,6 +148,7 @@ export const groupService = {
   updateMatchScore,
   generateBracket,
   scheduleMatch,
+  setGroupTiebreak,
 };
 
 export default groupService;

--- a/src/types/groups.ts
+++ b/src/types/groups.ts
@@ -5,6 +5,8 @@ export interface Group {
   groupLetter: string;
   groupOrder?: number;
   teams: GroupTeam[];
+  /** Manual tiebreak order: teamIds ordered by rank (set by organizer) */
+  tieBreakOrder?: string[] | null;
 }
 
 export interface GroupTeam {
@@ -113,6 +115,7 @@ export interface MatchesResponse {
   bracketType?: string;
   playoffRounds?: PlayoffRound[];
   teams: { id: string; name: string; clubName?: string }[];
+  advancingTeamsPerGroup?: number;
 }
 
 export interface UpdateMatchAdvancementDto {


### PR DESCRIPTION
## Summary

Frontend changes to support the group tiebreak feature and fix a UI loading flash.

### 1. Group Tiebreak Picker UI
Organizers can now resolve tied group standings directly from the Matches tab.

**Changes:**
- `src/types/groups.ts` — `Group.tieBreakOrder?: string[] | null`; `MatchesResponse.advancingTeamsPerGroup?: number`
- `src/services/group.service.ts` — `setGroupTiebreak(groupId, order)` API call
- `src/components/ui/StandingsTable.tsx` — amber panel UI with team buttons; selected winner shows `✓` and `(tiebreak winner)` label; new props: `canEdit`, `tiebreakOrder`, `onTiebreakerSet`
- `src/components/ui/MatchManagement.tsx` — `handleTiebreakerSet` callback; passes tiebreak props down to each `StandingsTable`

### 2. Fix: Parallel Fetch Eliminates Loading Flash
**Before:** Navigating to the Matches tab first showed a merged "Group Standings" table with all 8 teams for ~3 seconds, accompanied by false tie warnings (⚠) in the rank column.

**Root cause:** `getGroups` was triggered by a second `useEffect` that only fired after `matchData` was set, creating a sequential gap where `groups = []` caused the combined render.

**Fix:** `getGroups` is now called inside `fetchMatches` immediately after `getMatches` resolves (for group-format tournaments). The `loading` state stays `true` until both fetches complete, so the first render already has all group data — no flash.

## Files Changed
| File | Change |
|------|--------|
| `src/types/groups.ts` | `tieBreakOrder` field on `Group`; `advancingTeamsPerGroup` on `MatchesResponse` |
| `src/services/group.service.ts` | `setGroupTiebreak()` method |
| `src/components/ui/StandingsTable.tsx` | Tiebreak picker UI |
| `src/components/ui/MatchManagement.tsx` | Tiebreak wiring + parallel fetch fix |

## Related
- Backend PR: Sport-Tournaments/sport-tournaments-backend#140