### PR TITLE
fix: derive tournament dates from age groups in dashboard list

### DIFF
--- a/.github/instructions/frontend-conventions.instructions.md
+++ b/.github/instructions/frontend-conventions.instructions.md
@@ -1,0 +1,141 @@
+---
+description: "Use when creating or modifying Next.js frontend files: pages, components, layouts, hooks, services, or utility functions. Covers App Router structure, component organization, path aliases, API service layer, and i18n usage."
+applyTo: "src/**/*.{ts,tsx}"
+---
+
+# Frontend Next.js Conventions
+
+## App Router Structure
+
+This project uses the **Next.js App Router** (`src/app/`). File-based routing with:
+- `layout.tsx` — layout wrapper (server component by default)
+- `page.tsx` — route entry point
+- `providers.tsx` — client-side providers (React Query, i18n, toast)
+- `'use client'` directive required for any component using hooks, browser APIs, or event handlers
+
+```
+src/app/
+├── layout.tsx          ← root layout, wraps with <Providers>
+├── page.tsx            ← home page
+├── providers.tsx       ← QueryClientProvider, i18n init, Toaster
+├── auth/
+│   ├── login/page.tsx
+│   └── register/page.tsx
+└── dashboard/
+    └── page.tsx        ← protected route
+```
+
+## Component Organization
+
+```
+src/components/
+├── ui/           ← dumb, reusable: Button, Card, Modal, Input, Badge, Avatar
+├── layout/       ← Navigation, Header, Sidebar, Footer
+└── <feature>/    ← feature components with business logic
+```
+
+**Rules:**
+- `ui/` components have no business logic, no store access, no API calls
+- Feature components may connect to stores and services
+- `'use client'` only where needed — keep server components as default
+
+## Path Aliases
+
+Always use aliases, never relative paths deeper than one level:
+
+```typescript
+import { Button } from '@/components/ui/Button';
+import { useAuthStore } from '@/store/auth.store';
+import { tournamentService } from '@/services/tournament.service';
+import { Tournament } from '@/types/tournament';
+import { formatDate } from '@/utils/helpers';
+```
+
+Configured aliases: `@/components/*`, `@/app/*`, `@/services/*`, `@/utils/*`, `@/hooks/*`, `@/types/*`, `@/styles/*`, `@/store/*`, `@/i18n/*`.
+
+## API Service Layer
+
+All API calls go through `src/services/api.ts` (Axios instance) and dedicated service modules. Never call `axios` directly in components.
+
+```typescript
+// services/tournament.service.ts
+import { api } from './api';
+import { Tournament, CreateTournamentDto } from '@/types/tournament';
+
+export const tournamentService = {
+  getAll: (params?: Record<string, unknown>) =>
+    api.get<Tournament[]>('/v1/tournaments', { params }).then(r => r.data),
+
+  getById: (id: string) =>
+    api.get<Tournament>(`/v1/tournaments/${id}`).then(r => r.data),
+
+  create: (dto: CreateTournamentDto) =>
+    api.post<Tournament>('/v1/tournaments', dto).then(r => r.data),
+
+  update: (id: string, dto: Partial<CreateTournamentDto>) =>
+    api.patch<Tournament>(`/v1/tournaments/${id}`, dto).then(r => r.data),
+};
+```
+
+The Axios instance automatically attaches the JWT Bearer token from cookies and handles 401/token refresh.
+
+## i18n (Internationalization)
+
+Supported languages: English (`en`, default) and Romanian (`ro`).
+
+```tsx
+'use client';
+import { useTranslation } from 'react-i18next';
+
+export function TournamentCard({ tournament }: Props) {
+  const { t } = useTranslation();
+  return <h2>{t('tournament.title')}</h2>;
+}
+```
+
+Translation keys live in `src/i18n/locales/en.json` and `ro.json`. Always add translations for both locales when adding new text.
+
+## Styling
+
+**Tailwind CSS 4.0** — utility-first, no custom CSS unless unavoidable. Class-based dark mode (`.dark`), but the app is forced light-mode.
+
+```tsx
+// Prefer Tailwind utilities
+<button className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+  Submit
+</button>
+```
+
+Use `classnames` for conditional classes:
+```typescript
+import cn from 'classnames';
+<div className={cn('base-class', { 'active-class': isActive, 'error-class': hasError })} />
+```
+
+## TypeScript
+
+Strict mode enabled (`strict: true`). All component props must be explicitly typed:
+
+```typescript
+interface TournamentCardProps {
+  tournament: Tournament;
+  onRegister?: (id: string) => void;
+  className?: string;
+}
+
+export function TournamentCard({ tournament, onRegister, className }: TournamentCardProps) {}
+```
+
+## Custom Hooks
+
+Business logic hooks live in `src/hooks/`. Available hooks: `useAuth`, `useToast`, `useDebounce`, `usePagination`, `useMediaQuery`, `useInfiniteScroll`.
+
+```typescript
+// hooks/useTournaments.ts
+export function useTournaments(filters?: FilterDto) {
+  return useQuery({
+    queryKey: ['tournaments', filters],
+    queryFn: () => tournamentService.getAll(filters),
+  });
+}
+```

--- a/.github/instructions/frontend-state-forms.instructions.md
+++ b/.github/instructions/frontend-state-forms.instructions.md
@@ -1,0 +1,172 @@
+---
+description: "Use when working with state management, forms, API data fetching, or validation in the frontend. Covers Zustand store patterns, React Query for server state, React Hook Form with Zod validation, and authentication state."
+applyTo: "src/**/*.{ts,tsx}"
+---
+
+# Frontend State Management, Forms & Data Fetching
+
+## Zustand Stores (Client State)
+
+Stores live in `src/store/`. Use `persist` middleware for state that should survive page refreshes.
+
+```typescript
+// store/example.store.ts
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface ExampleState {
+  items: Item[];
+  isLoading: boolean;
+  error: string | null;
+  // Actions
+  setItems: (items: Item[]) => void;
+  addItem: (item: Item) => Promise<void>;
+  clearError: () => void;
+}
+
+export const useExampleStore = create<ExampleState>()(
+  persist(
+    (set, get) => ({
+      items: [],
+      isLoading: false,
+      error: null,
+
+      setItems: (items) => set({ items }),
+
+      addItem: async (item) => {
+        set({ isLoading: true, error: null });
+        try {
+          const created = await itemService.create(item);
+          set((state) => ({ items: [...state.items, created], isLoading: false }));
+        } catch (err) {
+          set({ error: 'Failed to add item', isLoading: false });
+        }
+      },
+
+      clearError: () => set({ error: null }),
+    }),
+    { name: 'example-storage' }  // localStorage key
+  )
+);
+```
+
+**Existing stores:** `useAuthStore` (auth state + actions), `useUIStore` (modals, sidebars), `useNotificationStore`.
+
+Use Zustand for **client-only** state (auth session, UI state). Use React Query for **server state**.
+
+## React Query (Server State)
+
+```typescript
+'use client';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { tournamentService } from '@/services/tournament.service';
+
+// Fetching
+export function useTournaments(filters?: FilterDto) {
+  return useQuery({
+    queryKey: ['tournaments', filters],
+    queryFn: () => tournamentService.getAll(filters),
+    staleTime: 5 * 60 * 1000,  // 5 min
+  });
+}
+
+// Mutations
+export function useCreateTournament() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: tournamentService.create,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tournaments'] });
+    },
+  });
+}
+```
+
+`QueryClientProvider` is set up in `src/app/providers.tsx` — no extra setup needed.
+
+## React Hook Form + Zod (Forms)
+
+All forms use `react-hook-form` with `zodResolver` for validation. Zod schemas are the single source of truth for types and validation.
+
+```typescript
+'use client';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+
+// 1. Define schema
+const loginSchema = z.object({
+  email: z.string().email('Invalid email address'),
+  password: z.string().min(8, 'Password must be at least 8 characters'),
+});
+
+type LoginFormData = z.infer<typeof loginSchema>;
+
+// 2. Use in component
+export function LoginForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    setError,
+  } = useForm<LoginFormData>({
+    resolver: zodResolver(loginSchema),
+  });
+
+  const onSubmit = async (data: LoginFormData) => {
+    try {
+      await authService.login(data);
+    } catch (err) {
+      setError('root', { message: 'Invalid credentials' });
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input {...register('email')} />
+      {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
+
+      <input type="password" {...register('password')} />
+      {errors.password && <p className="text-red-500 text-sm">{errors.password.message}</p>}
+
+      {errors.root && <p className="text-red-500">{errors.root.message}</p>}
+
+      <button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? 'Loading...' : 'Login'}
+      </button>
+    </form>
+  );
+}
+```
+
+## Authentication State
+
+Auth state is managed by `useAuthStore`. Access it from any component:
+
+```typescript
+import { useAuthStore } from '@/store/auth.store';
+
+// Read state
+const { user, isAuthenticated, isLoading } = useAuthStore();
+
+// Actions
+const { login, logout, fetchCurrentUser } = useAuthStore();
+```
+
+**Auth flow:** tokens stored in cookies → Axios interceptor attaches Bearer token → on 401, interceptor auto-refreshes → on 403 or failed refresh, `clearAuth()` + redirect to `/auth/login`.
+
+`fetchCurrentUser()` is called on app mount (in `providers.tsx`) to restore session.
+
+## File Uploads
+
+Use `react-dropzone` for file upload components:
+
+```typescript
+import { useDropzone } from 'react-dropzone';
+
+const { getRootProps, getInputProps, isDragActive } = useDropzone({
+  accept: { 'image/*': ['.jpeg', '.jpg', '.png'] },
+  maxSize: 5 * 1024 * 1024,  // 5MB
+  onDrop: (files) => handleUpload(files),
+});
+```

--- a/.github/instructions/frontend-testing.instructions.md
+++ b/.github/instructions/frontend-testing.instructions.md
@@ -1,0 +1,146 @@
+---
+description: "Use when writing, running, or debugging frontend tests. Covers Vitest unit/integration tests with React Testing Library, MSW for API mocking, Playwright e2e tests, and coverage configuration."
+applyTo: "src/**/*.{test,spec}.{ts,tsx}"
+---
+
+# Frontend Testing Patterns
+
+## Test Runners
+
+| Type | Tool | Location |
+|---|---|---|
+| Unit / Integration | **Vitest** + React Testing Library | `src/**/*.{test,spec}.{ts,tsx}` |
+| E2E | **Playwright** | `src/__tests__/e2e/**` |
+
+Run unit tests: `pnpm test` / `pnpm vitest`  
+Run e2e: `pnpm playwright test`
+
+## Vitest Unit/Integration Test Pattern
+
+```typescript
+// src/__tests__/integration/TournamentCard.test.tsx
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TournamentCard } from '@/components/TournamentCard';
+
+describe('TournamentCard', () => {
+  const mockTournament = {
+    id: '1',
+    name: 'Spring Open 2024',
+    status: 'OPEN',
+  };
+
+  it('renders tournament name', () => {
+    render(<TournamentCard tournament={mockTournament} />);
+    expect(screen.getByText('Spring Open 2024')).toBeInTheDocument();
+  });
+
+  it('calls onRegister with tournament id when button clicked', async () => {
+    const onRegister = vi.fn();
+    render(<TournamentCard tournament={mockTournament} onRegister={onRegister} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /register/i }));
+    await waitFor(() => expect(onRegister).toHaveBeenCalledWith('1'));
+  });
+});
+```
+
+## Test Setup
+
+Global setup is in `src/__tests__/setup.ts`. It imports `@testing-library/jest-dom` matchers. Tests run in `jsdom` environment with `globals: true` (no need to import `describe`, `it`, `expect`).
+
+Wrap components that need providers (React Query, i18n) with a custom render utility:
+
+```typescript
+// src/__tests__/utils/render.tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+
+const createTestQueryClient = () => new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+export function renderWithProviders(ui: React.ReactElement) {
+  const client = createTestQueryClient();
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+  );
+}
+```
+
+## MSW (API Mocking)
+
+Mock API calls with MSW handlers in `src/__tests__/mocks/`:
+
+```typescript
+// src/__tests__/mocks/handlers.ts
+import { http, HttpResponse } from 'msw';
+
+export const handlers = [
+  http.get('/api/v1/tournaments', () =>
+    HttpResponse.json({ success: true, data: [mockTournament] })
+  ),
+
+  http.post('/api/v1/auth/login', async ({ request }) => {
+    const body = await request.json() as { email: string };
+    if (body.email === 'test@example.com') {
+      return HttpResponse.json({ success: true, data: { accessToken: 'mock-token' } });
+    }
+    return HttpResponse.json({ success: false }, { status: 401 });
+  }),
+];
+```
+
+Start MSW server in setup file:
+```typescript
+// src/__tests__/setup.ts
+import { setupServer } from 'msw/node';
+import { handlers } from './mocks/handlers';
+
+const server = setupServer(...handlers);
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+```
+
+## Zustand Store Testing
+
+Reset store state between tests:
+
+```typescript
+import { useAuthStore } from '@/store/auth.store';
+
+beforeEach(() => {
+  useAuthStore.setState({ user: null, isAuthenticated: false });
+});
+```
+
+## Playwright E2E Tests
+
+```typescript
+// src/__tests__/e2e/auth.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('user can login successfully', async ({ page }) => {
+  await page.goto('/auth/login');
+
+  await page.fill('[name="email"]', 'test@example.com');
+  await page.fill('[name="password"]', 'Password1!');
+  await page.click('[type="submit"]');
+
+  await expect(page).toHaveURL('/dashboard');
+  await expect(page.locator('h1')).toContainText('Dashboard');
+});
+```
+
+Config in `playwright.config.ts` — base URL defaults to `http://localhost:3000`.
+
+## Coverage Thresholds
+
+Configured in `vitest.config.ts`:
+- Lines: 25%
+- Functions: 40%
+- Branches: 70%
+- Statements: 25%
+
+Excluded: `node_modules`, `dist`, `.next`, `e2e/**`.

--- a/src/app/dashboard/tournaments/page.tsx
+++ b/src/app/dashboard/tournaments/page.tsx
@@ -60,17 +60,26 @@ export default function DashboardTournamentsPage() {
     fetchData: fetchTournaments,
   });
 
+  const getEffectiveDates = (tournament: Tournament): { startDate: string | undefined; endDate: string | undefined } => {
+    const startDate = tournament.startDate
+      ?? tournament.ageGroups?.map((ag) => ag.startDate).filter(Boolean).sort()[0];
+    const endDate = tournament.endDate
+      ?? tournament.ageGroups?.map((ag) => ag.endDate).filter(Boolean).sort().reverse()[0];
+    return { startDate, endDate };
+  };
+
   const getEffectiveTournamentStatus = (tournament: Tournament): TournamentStatus => {
     if (tournament.status === 'CANCELLED') {
       return 'CANCELLED';
     }
 
-    if (tournament.endDate) {
-      const endDate = new Date(tournament.endDate);
+    const { endDate } = getEffectiveDates(tournament);
+    if (endDate) {
+      const endDateObj = new Date(endDate);
       const today = new Date();
       today.setHours(0, 0, 0, 0);
 
-      if (!Number.isNaN(endDate.getTime()) && endDate < today) {
+      if (!Number.isNaN(endDateObj.getTime()) && endDateObj < today) {
         return 'COMPLETED';
       }
     }
@@ -200,7 +209,7 @@ export default function DashboardTournamentsPage() {
                             </Badge>
                           </div>
                           <div className="text-sm text-gray-500">
-                            {formatDate(tournament.startDate)} - {formatDate(tournament.endDate)}
+                            {(() => { const { startDate, endDate } = getEffectiveDates(tournament); return `${formatDate(startDate)} - ${formatDate(endDate)}`; })()}
                           </div>
                           <div className="text-sm text-gray-500 mt-1">
                             {getRegisteredTeamsDisplay(tournament)} / {getMaxTeamsDisplay(tournament)} {t('common.teams')}
@@ -258,7 +267,7 @@ export default function DashboardTournamentsPage() {
                               </Badge>
                             </div>
                             <div className="text-sm text-gray-500 mt-2">
-                              {formatDate(tournament.startDate)} - {formatDate(tournament.endDate)}
+                              {(() => { const { startDate, endDate } = getEffectiveDates(tournament); return `${formatDate(startDate)} - ${formatDate(endDate)}`; })()}
                             </div>
                             <div className="text-sm text-gray-500 mt-1">
                               {getRegisteredTeamsDisplay(tournament)} / {getMaxTeamsDisplay(tournament)} {t('common.teams')}


### PR DESCRIPTION
Closes #291, closes #292

## Changes

### Bug fix — tournament dates not shown in dashboard

The My Tournaments dashboard displayed `— - —` for tournaments whose `startDate`/`endDate` are `null` at the tournament level (dates stored per age group only).

**`getEffectiveDates()` helper** added to `page.tsx`:
```typescript
const getEffectiveDates = (tournament: Tournament) => {
  const startDate = tournament.startDate
    ?? tournament.ageGroups?.map((ag) => ag.startDate).filter(Boolean).sort()[0];
  const endDate = tournament.endDate
    ?? tournament.ageGroups?.map((ag) => ag.endDate).filter(Boolean).sort().reverse()[0];
  return { startDate, endDate };
};
```

Both **list view** and **grid view** use this helper for date display.

`getEffectiveTournamentStatus()` also uses `getEffectiveDates()` so the `COMPLETED` badge is computed correctly when only age group end dates have passed.

### Docs — GitHub Copilot instruction files

Added `.github/instructions/` files so Copilot automatically applies project conventions when working on frontend source files:

| File | Scope |
|---|---|
| `frontend-conventions.instructions.md` | `src/**/*.{ts,tsx}` |
| `frontend-state-forms.instructions.md` | `src/**/*.{ts,tsx}` |
| `frontend-testing.instructions.md` | `src/**/*.{test,spec}.{ts,tsx}` |

## Testing

Validated end-to-end with Playwright: created tournament "Date Fix Test 2026" with age groups dated 2026-06-01 → 2026-06-05; My Tournaments dashboard correctly shows `01.06.2026 - 05.06.2026`.