### PR TITLE
feat: per-age-group registration toggle UI

### DIFF
--- a/src/app/dashboard/tournaments/[id]/page.tsx
+++ b/src/app/dashboard/tournaments/[id]/page.tsx
@@ -24,6 +24,7 @@ export default function TournamentDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const [downloadingRegulations, setDownloadingRegulations] = useState(false);
   const [updatingRegistrations, setUpdatingRegistrations] = useState(false);
+  const [updatingAgeGroupRegistrations, setUpdatingAgeGroupRegistrations] = useState<string | null>(null);
   const [groups, setGroups] = useState<any[]>([]);
   
   // Rejection modal state
@@ -162,6 +163,20 @@ export default function TournamentDetailPage() {
       setError(err.response?.data?.message || 'Failed to stop registrations');
     } finally {
       setUpdatingRegistrations(false);
+    }
+  };
+
+  const handleToggleAgeGroupRegistrations = async (ageGroupId: string, close: boolean) => {
+    if (!tournament) return;
+    setUpdatingAgeGroupRegistrations(ageGroupId);
+    setError(null);
+    try {
+      await tournamentService.setAgeGroupRegistrationClosed(tournament.id, ageGroupId, close);
+      await fetchData();
+    } catch (err: any) {
+      setError(err.response?.data?.message || 'Failed to update age group registration status');
+    } finally {
+      setUpdatingAgeGroupRegistrations(null);
     }
   };
 
@@ -779,11 +794,45 @@ export default function TournamentDetailPage() {
         label: getAgeGroupLabel(ageGroup),
         count: getPendingBadgeCount(ageGroup.id),
         content: (
-          <Tabs
-            tabs={buildTabsForAgeGroup(ageGroup)}
-            defaultTab={searchParams.get('tab') ?? 'overview'}
-            variant="pills-gray"
-          />
+          <div className="space-y-4">
+            {tournament.status === 'PUBLISHED' && ageGroup.id && !ageGroup.isRegistrationClosed && (
+              <Alert variant="info" className="flex items-center justify-between">
+                <div className="flex w-full items-center gap-3">
+                  <span className="min-w-0">Registrations are open for {getAgeGroupLabel(ageGroup)}.</span>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    className="ml-auto"
+                    onClick={() => handleToggleAgeGroupRegistrations(ageGroup.id!, true)}
+                    isLoading={updatingAgeGroupRegistrations === ageGroup.id}
+                  >
+                    Stop Registrations
+                  </Button>
+                </div>
+              </Alert>
+            )}
+            {tournament.status === 'PUBLISHED' && ageGroup.id && ageGroup.isRegistrationClosed && (
+              <Alert variant="warning" className="flex items-center justify-between">
+                <div className="flex w-full items-center gap-3">
+                  <span className="min-w-0">Registrations are closed for {getAgeGroupLabel(ageGroup)}.</span>
+                  <Button
+                    variant="success"
+                    size="sm"
+                    className="ml-auto"
+                    onClick={() => handleToggleAgeGroupRegistrations(ageGroup.id!, false)}
+                    isLoading={updatingAgeGroupRegistrations === ageGroup.id}
+                  >
+                    Open Registrations
+                  </Button>
+                </div>
+              </Alert>
+            )}
+            <Tabs
+              tabs={buildTabsForAgeGroup(ageGroup)}
+              defaultTab={searchParams.get('tab') ?? 'overview'}
+              variant="pills-gray"
+            />
+          </div>
         ),
       }))
     : tabs;
@@ -839,7 +888,7 @@ export default function TournamentDetailPage() {
 
         {/* Status Actions */}
 
-        {tournament.status === 'PUBLISHED' && !tournament.isRegistrationClosed && (
+        {tournament.status === 'PUBLISHED' && !tournament.isRegistrationClosed && (!tournament.ageGroups || tournament.ageGroups.length === 0) && (
           <Alert variant="info" className="flex items-center justify-between">
             <div className="flex w-full items-center gap-3">
               <span className="min-w-0">{t('tournament.registrationOpenMessage')}</span>
@@ -856,7 +905,7 @@ export default function TournamentDetailPage() {
           </Alert>
         )}
 
-        {tournament.status === 'PUBLISHED' && tournament.isRegistrationClosed && (
+        {tournament.status === 'PUBLISHED' && tournament.isRegistrationClosed && (!tournament.ageGroups || tournament.ageGroups.length === 0) && (
           <Alert variant="warning" className="flex items-center justify-between">
             <span>{t('tournament.registrationClosed')}</span>
           </Alert>

--- a/src/services/tournament.service.ts
+++ b/src/services/tournament.service.ts
@@ -170,6 +170,18 @@ export async function updateTournamentAgeGroups(
   return apiPut<ApiResponse<AgeGroup[]>>(`${TOURNAMENTS_BASE}/${id}/age-groups`, { ageGroups });
 }
 
+// Set registration closed/open for a specific age group
+export async function setAgeGroupRegistrationClosed(
+  tournamentId: string,
+  ageGroupId: string,
+  isRegistrationClosed: boolean
+): Promise<ApiResponse<AgeGroup>> {
+  return apiPatch<ApiResponse<AgeGroup>>(
+    `${TOURNAMENTS_BASE}/${tournamentId}/age-groups/${ageGroupId}/registration-status`,
+    { isRegistrationClosed }
+  );
+}
+
 export const tournamentService = {
   getTournaments,
   searchTournaments,
@@ -191,6 +203,7 @@ export const tournamentService = {
   validateInvitationCode,
   getTournamentStatistics,
   updateTournamentAgeGroups,
+  setAgeGroupRegistrationClosed,
 };
 
 export default tournamentService;

--- a/src/types/tournament.ts
+++ b/src/types/tournament.ts
@@ -58,6 +58,7 @@ export interface AgeGroup {
   notes?: string;
   drawCompleted?: boolean;
   drawSeed?: string;
+  isRegistrationClosed?: boolean;
 }
 
 export interface TournamentLocation {


### PR DESCRIPTION
Closes #294

## Changes

- `AgeGroup` type: added `isRegistrationClosed?: boolean`
- `tournament.service.ts`: added `setAgeGroupRegistrationClosed()` function + exported in `tournamentService`
- `dashboard/tournaments/[id]/page.tsx`:
  - Added `updatingAgeGroupRegistrations` state
  - Added `handleToggleAgeGroupRegistrations()` handler
  - Per-age-group registration status alerts with Stop/Open buttons in each age group tab
  - Tournament-level alert scoped to tournaments with no age groups

## Related backend PR
Sport-Tournaments/sport-tournaments-backend#172