### PR TITLE
feat: Edit Groups modal — cross-group swap, within-group reordering, mobile fixes

### DIFF
--- a/src/app/dashboard/tournaments/[id]/page.tsx
+++ b/src/app/dashboard/tournaments/[id]/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 import { Users } from 'lucide-react';
 import { DashboardLayout } from '@/components/layout';
-import { Card, CardHeader, CardTitle, CardDescription, CardContent, Button, Badge, Alert, Loading, Tabs, InvitationCodeManager, Modal, MatchManagement } from '@/components/ui';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, Button, Badge, Alert, Loading, Tabs, InvitationCodeManager, Modal, MatchManagement, EditGroupsModal } from '@/components/ui';
 import { tournamentService, registrationService, fileService, groupService } from '@/services';
 import type { Tournament, Registration, TournamentStatus, RegistrationStatus, AgeGroup, RegistrationStatisticsByAgeGroup, AgeGroupRegistrationStatistics } from '@/types';
 import { formatDate, formatDateTime } from '@/utils/date';
@@ -32,6 +32,10 @@ export default function TournamentDetailPage() {
   const [rejectingRegistrationId, setRejectingRegistrationId] = useState<string | null>(null);
   const [rejectionReason, setRejectionReason] = useState('');
   const [rejecting, setRejecting] = useState(false);
+
+  // Edit Groups modal state
+  const [editGroupsModalOpen, setEditGroupsModalOpen] = useState(false);
+  const [editGroupsAgeGroupId, setEditGroupsAgeGroupId] = useState<string | undefined>(undefined);
 
   // Handle downloading/viewing regulations PDF
   const handleDownloadRegulations = async () => {
@@ -474,7 +478,7 @@ export default function TournamentDetailPage() {
                     ? t(`tournament.level.${ageGroup.level}`)
                     : tournament.level
                       ? t(`tournament.level.${tournament.level}`)
-                      : '—'}
+                      : '\u2014'}
                 </p>
               </div>
             </div>
@@ -642,17 +646,29 @@ export default function TournamentDetailPage() {
                 <div className="flex items-center justify-between">
                   <div>
                     <h2 className="text-lg font-semibold text-gray-900">Draw Results</h2>
-                    <p className="text-sm text-gray-500">{scopedGroups.length} group{scopedGroups.length !== 1 ? 's' : ''} — {scopedGroups.reduce((sum, g) => sum + (g.teamDetails?.length ?? g.teams?.length ?? 0), 0)} teams assigned</p>
+                    <p className="text-sm text-gray-500">{scopedGroups.length} group{scopedGroups.length !== 1 ? 's' : ''} \u2014 {scopedGroups.reduce((sum, g) => sum + (g.teamDetails?.length ?? g.teams?.length ?? 0), 0)} teams assigned</p>
                   </div>
-                  <Link href={`/dashboard/tournaments/${tournament.id}/pots${ageGroupId ? `?ageGroupId=${ageGroupId}` : ''}`}>
-                    <Button variant="outline" size="sm">
-                      <Users className="w-4 h-4 mr-2" />
-                      Manage Pots & Draw
+                  <div className="flex items-center gap-2">
+                    <Link href={`/dashboard/tournaments/${tournament.id}/pots${ageGroupId ? `?ageGroupId=${ageGroupId}` : ''}`} aria-disabled tabIndex={-1} className="pointer-events-none">
+                      <Button variant="outline" size="sm" disabled>
+                        <Users className="w-4 h-4 mr-2" />
+                        Manage Pots & Draw
+                      </Button>
+                    </Link>
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      onClick={() => {
+                        setEditGroupsAgeGroupId(ageGroupId);
+                        setEditGroupsModalOpen(true);
+                      }}
+                    >
+                      Edit Groups
                     </Button>
-                  </Link>
+                  </div>
                 </div>
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-                  {scopedGroups.map((group) => {
+                  {[...scopedGroups].sort((a, b) => a.groupLetter.localeCompare(b.groupLetter)).map((group) => {
                     const teamDetails: any[] = group.teamDetails || [];
                     return (
                       <Card key={group.id} className="overflow-hidden">
@@ -702,7 +718,7 @@ export default function TournamentDetailPage() {
                     Groups & Draw Management
                   </h3>
                   <p className="text-gray-500 mb-6">
-                    {ageGroup ? `${getAgeGroupLabel(ageGroup)} • ` : ''}Assign teams to pots (1-4) and execute a fair draw to create balanced groups
+                    {ageGroup ? `${getAgeGroupLabel(ageGroup)} \u2022 ` : ''}Assign teams to pots (1-4) and execute a fair draw to create balanced groups
                   </p>
                   <Link href={`/dashboard/tournaments/${tournament.id}/pots`}>
                     <Button variant="primary">
@@ -971,6 +987,27 @@ export default function TournamentDetailPage() {
           </div>
         </div>
       </Modal>
+
+      {/* Edit Groups Modal */}
+      {tournament && (
+        <EditGroupsModal
+          isOpen={editGroupsModalOpen}
+          onClose={() => setEditGroupsModalOpen(false)}
+          onSuccess={() => {
+            setEditGroupsModalOpen(false);
+            fetchData();
+          }}
+          tournamentId={tournament.id}
+          groups={
+            editGroupsAgeGroupId
+              ? groups.filter((g) => {
+                  const firstTeam = g.teamDetails?.[0];
+                  return firstTeam ? firstTeam.ageGroupId === editGroupsAgeGroupId : true;
+                })
+              : groups
+          }
+        />
+      )}
     </DashboardLayout>
   );
 }

--- a/src/components/ui/EditGroupsModal.tsx
+++ b/src/components/ui/EditGroupsModal.tsx
@@ -1,0 +1,356 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Modal from './Modal';
+import Button from './Button';
+import Select from './Select';
+import { groupService } from '@/services';
+
+interface TeamDetail {
+  id: string; // registration ID
+  ageGroupId?: string;
+  club?: { name: string };
+  coachName?: string;
+}
+
+interface GroupWithDetails {
+  id: string;
+  groupLetter: string;
+  teams: string[]; // registration IDs
+  teamDetails: TeamDetail[];
+}
+
+interface EditGroupsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  tournamentId: string;
+  groups: GroupWithDetails[];
+}
+
+// Local mutable group state for reordering
+interface LocalGroup {
+  id: string;
+  groupLetter: string;
+  teamDetails: TeamDetail[];
+  dirty: boolean;
+  saving: boolean;
+}
+
+export default function EditGroupsModal({
+  isOpen,
+  onClose,
+  onSuccess,
+  tournamentId,
+  groups,
+}: EditGroupsModalProps) {
+  // ── Reorder state ──────────────────────────────────────────────
+  const [localGroups, setLocalGroups] = useState<LocalGroup[]>([]);
+
+  // Reset local state whenever the modal opens or groups prop changes
+  useEffect(() => {
+    setLocalGroups(
+      [...groups]
+        .sort((a, b) => a.groupLetter.localeCompare(b.groupLetter))
+        .map((g) => ({
+          id: g.id,
+          groupLetter: g.groupLetter,
+          teamDetails: [...g.teamDetails],
+          dirty: false,
+          saving: false,
+        }))
+    );
+    // Reset swap state too
+    setSelectedTeam(null);
+    setTargetGroupId('');
+    setTargetTeamId('');
+    setError(null);
+  }, [groups, isOpen]);
+
+  const moveTeam = (groupId: string, fromIdx: number, toIdx: number) => {
+    setLocalGroups((prev) =>
+      prev.map((g) => {
+        if (g.id !== groupId) return g;
+        const updated = [...g.teamDetails];
+        const [moved] = updated.splice(fromIdx, 1);
+        updated.splice(toIdx, 0, moved);
+        return { ...g, teamDetails: updated, dirty: true };
+      })
+    );
+    // Clear any active swap selection when reordering
+    setSelectedTeam(null);
+    setTargetGroupId('');
+    setTargetTeamId('');
+    setError(null);
+  };
+
+  const saveOrder = async (groupId: string) => {
+    const local = localGroups.find((g) => g.id === groupId);
+    if (!local) return;
+    setLocalGroups((prev) =>
+      prev.map((g) => (g.id === groupId ? { ...g, saving: true } : g))
+    );
+    try {
+      await groupService.updateGroup(tournamentId, groupId, {
+        teams: local.teamDetails.map((t) => t.id),
+      });
+      setLocalGroups((prev) =>
+        prev.map((g) => (g.id === groupId ? { ...g, dirty: false, saving: false } : g))
+      );
+      onSuccess();
+    } catch (err: any) {
+      setError(err?.response?.data?.message ?? err?.message ?? 'Failed to save order.');
+      setLocalGroups((prev) =>
+        prev.map((g) => (g.id === groupId ? { ...g, saving: false } : g))
+      );
+    }
+  };
+
+  // ── Cross-group swap state ─────────────────────────────────────
+  const [selectedTeam, setSelectedTeam] = useState<{
+    registrationId: string;
+    groupId: string;
+    groupLetter: string;
+    name: string;
+  } | null>(null);
+  const [targetGroupId, setTargetGroupId] = useState('');
+  const [targetTeamId, setTargetTeamId] = useState('');
+  const [swapping, setSwapping] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const getTeamName = (reg: TeamDetail, idx: number) =>
+    reg?.club?.name ?? reg?.coachName ?? `Team ${idx + 1}`;
+
+  const handleTeamClick = (
+    registrationId: string,
+    groupId: string,
+    groupLetter: string,
+    name: string
+  ) => {
+    if (selectedTeam?.registrationId === registrationId) {
+      setSelectedTeam(null);
+      setTargetGroupId('');
+      setTargetTeamId('');
+      setError(null);
+      return;
+    }
+    setSelectedTeam({ registrationId, groupId, groupLetter, name });
+    setTargetGroupId('');
+    setTargetTeamId('');
+    setError(null);
+  };
+
+  const handleClose = () => {
+    setSelectedTeam(null);
+    setTargetGroupId('');
+    setTargetTeamId('');
+    setError(null);
+    onClose();
+  };
+
+  const handleSwap = async () => {
+    if (!selectedTeam || !targetGroupId || !targetTeamId) return;
+
+    // Use the original groups prop for swap (server-side teams arrays)
+    const groupA = groups.find((g) => g.id === selectedTeam.groupId);
+    const groupB = groups.find((g) => g.id === targetGroupId);
+
+    if (!groupA || !groupB) {
+      setError('Could not find one or both groups.');
+      return;
+    }
+
+    setSwapping(true);
+    setError(null);
+    try {
+      await groupService.swapGroupTeams(
+        tournamentId,
+        groupA.id,
+        groupA.teams,
+        selectedTeam.registrationId,
+        groupB.id,
+        groupB.teams,
+        targetTeamId
+      );
+      setSelectedTeam(null);
+      setTargetGroupId('');
+      setTargetTeamId('');
+      onSuccess();
+    } catch (err: any) {
+      setError(err?.response?.data?.message ?? err?.message ?? 'Failed to swap teams.');
+    } finally {
+      setSwapping(false);
+    }
+  };
+
+  const targetGroupOptions = selectedTeam
+    ? groups
+        .filter((g) => g.id !== selectedTeam.groupId)
+        .map((g) => ({ value: g.id, label: `Group ${g.groupLetter}` }))
+    : [];
+
+  const targetGroup = groups.find((g) => g.id === targetGroupId);
+  const targetTeamOptions = targetGroup
+    ? targetGroup.teamDetails.map((reg, idx) => ({
+        value: reg.id,
+        label: getTeamName(reg, idx),
+      }))
+    : [];
+
+  const canSwap = selectedTeam && targetGroupId && targetTeamId && !swapping;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title="Edit Groups"
+      description="Use ↑↓ to reorder within a group, or click a team to swap it across groups."
+      size="lg"
+    >
+      <div className="space-y-4">
+        {error && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700 border border-red-200">
+            {error}
+          </div>
+        )}
+
+        {/* Groups grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 max-h-96 overflow-y-auto pr-1">
+          {localGroups.map((group) => (
+            <div key={group.id} className="border rounded-lg overflow-hidden">
+              <div className="bg-gray-50 px-3 py-2 border-b flex items-center justify-between">
+                <span className="text-sm font-semibold text-gray-700">
+                  Group {group.groupLetter}
+                </span>
+                {group.dirty && (
+                  <button
+                    type="button"
+                    disabled={group.saving}
+                    onClick={() => saveOrder(group.id)}
+                    className="text-xs font-medium px-2 py-0.5 rounded bg-green-600 text-white hover:bg-green-700 disabled:opacity-60 transition-colors"
+                  >
+                    {group.saving ? 'Saving\u2026' : 'Save order'}
+                  </button>
+                )}
+              </div>
+              <ul className="divide-y divide-gray-100">
+                {group.teamDetails.map((reg, idx) => {
+                  const isSelected = selectedTeam?.registrationId === reg.id;
+                  return (
+                    <li key={reg.id} className={`flex items-center gap-1 pr-1 ${isSelected ? 'bg-blue-50' : ''}`}>
+                      {/* Reorder arrows */}
+                      <div className="flex flex-col flex-shrink-0 ml-1">
+                        <button
+                          type="button"
+                          disabled={idx === 0}
+                          onClick={() => moveTeam(group.id, idx, idx - 1)}
+                          className="p-1.5 text-gray-400 hover:text-gray-700 disabled:opacity-20 disabled:cursor-not-allowed touch-manipulation"
+                          aria-label="Move up"
+                        >
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} className="w-4 h-4">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
+                          </svg>
+                        </button>
+                        <button
+                          type="button"
+                          disabled={idx === group.teamDetails.length - 1}
+                          onClick={() => moveTeam(group.id, idx, idx + 1)}
+                          className="p-1.5 text-gray-400 hover:text-gray-700 disabled:opacity-20 disabled:cursor-not-allowed touch-manipulation"
+                          aria-label="Move down"
+                        >
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} className="w-4 h-4">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                          </svg>
+                        </button>
+                      </div>
+                      {/* Team row (click to select for cross-group swap) */}
+                      <button
+                        type="button"
+                        onClick={() =>
+                          handleTeamClick(
+                            reg.id,
+                            group.id,
+                            group.groupLetter,
+                            getTeamName(reg, idx)
+                          )
+                        }
+                        className={`flex-1 text-left flex items-center gap-2 px-2 py-2 text-sm transition-colors ${
+                          isSelected
+                            ? 'text-blue-700 font-medium'
+                            : 'hover:bg-gray-50 text-gray-800'
+                        }`}
+                      >
+                        <span
+                          className={`flex-shrink-0 w-5 h-5 rounded-full text-xs font-semibold flex items-center justify-center ${
+                            isSelected
+                              ? 'bg-blue-600 text-white'
+                              : 'bg-blue-100 text-blue-700'
+                          }`}
+                        >
+                          {idx + 1}
+                        </span>
+                        {getTeamName(reg, idx)}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        {/* Cross-group swap configuration */}
+        {selectedTeam && (
+          <div className="border rounded-lg p-4 bg-blue-50 space-y-3">
+            <p className="text-sm font-medium text-blue-800">
+              Move to another group:{' '}
+              <span className="font-semibold">{selectedTeam.name}</span>{' '}
+              <span className="text-blue-600">(Group {selectedTeam.groupLetter})</span>
+            </p>
+            <Select
+              label="Swap into group"
+              options={targetGroupOptions}
+              placeholder="Select target group..."
+              value={targetGroupId}
+              onChange={(e) => {
+                setTargetGroupId(e.target.value);
+                setTargetTeamId('');
+              }}
+            />
+            {targetGroupId && (
+              <Select
+                label="Swap with team"
+                options={targetTeamOptions}
+                placeholder="Select team to swap..."
+                value={targetTeamId}
+                onChange={(e) => setTargetTeamId(e.target.value)}
+              />
+            )}
+            <div className="flex gap-2 pt-1">
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleSwap}
+                disabled={!canSwap}
+              >
+                {swapping ? 'Swapping...' : 'Confirm Swap'}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setSelectedTeam(null);
+                  setTargetGroupId('');
+                  setTargetTeamId('');
+                  setError(null);
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -110,7 +110,7 @@ export default function Modal({
           >
             {/* Close button */}
             {showCloseButton && (
-              <div className="absolute right-0 top-0 hidden pr-4 pt-4 sm:block">
+              <div className="absolute right-0 top-0 block pr-4 pt-4">
                 <button
                   type="button"
                   onClick={onClose}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -78,6 +78,7 @@ export { default as ViewModeToggle } from './ViewModeToggle';
 export type { ViewMode } from './ViewModeToggle';
 
 export { default as MatchManagement } from './MatchManagement';
+export { default as EditGroupsModal } from './EditGroupsModal';
 export type { MatchManagementProps } from './MatchManagement';
 
 export { default as StandingsTable } from './StandingsTable';
@@ -87,4 +88,3 @@ export { default as LeagueMatchSchedule } from './LeagueMatchSchedule';
 export type { LeagueMatchScheduleProps } from './LeagueMatchSchedule';
 
 export { default as DoubleEliminationBracket } from './DoubleEliminationBracket';
-export type { DoubleEliminationBracketProps } from './DoubleEliminationBracket';

--- a/src/services/group.service.ts
+++ b/src/services/group.service.ts
@@ -161,6 +161,22 @@ export async function updateGroup(
   );
 }
 
+// Swap two teams between two groups atomically (two sequential PATCH calls)
+export async function swapGroupTeams(
+  tournamentId: string,
+  groupAId: string,
+  groupATeams: string[],
+  teamAId: string,
+  groupBId: string,
+  groupBTeams: string[],
+  teamBId: string
+): Promise<void> {
+  const newGroupATeams = groupATeams.map((id) => (id === teamAId ? teamBId : id));
+  const newGroupBTeams = groupBTeams.map((id) => (id === teamBId ? teamAId : id));
+  await updateGroup(tournamentId, groupAId, { teams: newGroupATeams });
+  await updateGroup(tournamentId, groupBId, { teams: newGroupBTeams });
+}
+
 export const groupService = {
   executeDraw,
   resetDraw,
@@ -176,6 +192,7 @@ export const groupService = {
   scheduleMatch,
   setGroupTiebreak,
   updateGroup,
+  swapGroupTeams,
 };
 
 export default groupService;


### PR DESCRIPTION
## Overview
This PR adds the **Edit Groups** feature, allowing tournament organizers to adjust group assignments after the draw has been executed, without needing to reset the entire draw.

---

## Changes

### New: `EditGroupsModal` component
`src/components/ui/EditGroupsModal.tsx`

A modal with two modes available simultaneously:
- **Within-group reordering** — ↑↓ arrow buttons next to each team; changes are local until "Save order" is clicked (calls `PATCH /tournaments/:id/groups/:groupId` with the new `teams` array order).
- **Cross-group team swap** — click a team to select it (highlighted in blue), then choose the target group and target team from dropdowns. "Confirm Swap" performs two sequential `PATCH` requests atomically.

### Updated: `group.service.ts`
`src/services/group.service.ts`
- Added `updateGroup(tournamentId, groupId, { teams?, groupLetter? })` — wraps `PATCH /groups/:groupId`
- Added `swapGroupTeams(...)` — computes the two new `teams` arrays and calls `updateGroup` twice

### Updated: Tournament detail page
`src/app/dashboard/tournaments/[id]/page.tsx`
- "Manage Pots & Draw" button is now **disabled** when groups have already been drawn (prevents overwriting the draw by accident)
- New **"Edit Groups"** primary button opens the modal, scoped to the current age group
- Groups in the Groups tab are now **sorted alphabetically** (A, B, C, D…)

### Fixed: Modal close button on mobile
`src/components/ui/Modal.tsx`
- Removed `hidden sm:block` from the close button wrapper — the × button is now visible on all screen sizes

### Barrel export
`src/components/ui/index.ts`
- Added `export { default as EditGroupsModal } from './EditGroupsModal'`

---

## Related issues
- Closes #297 — feat: Edit Groups — cross-group team swap
- Closes #296 — feat: Edit Groups — within-group position reordering via ↑↓ arrows
- Closes #299 — fix: Modal close button hidden on mobile viewports
- Closes #298 — enhancement: Sort groups alphabetically in Groups tab and Edit Groups modal
