### PR TITLE
fix(bracket): pass age-group-level props to MatchManagement

### DIFF
--- a/src/app/dashboard/tournaments/[id]/page.tsx
+++ b/src/app/dashboard/tournaments/[id]/page.tsx
@@ -738,7 +738,7 @@ export default function TournamentDetailPage() {
         content: (() => {
           // Formats that require groups to be drawn before matches can be generated
           const format = ageGroup?.format;
-          const needsGroups = format === 'GROUPS_PLUS_KNOCKOUT' || format === 'LEAGUE';
+          const needsGroups = format === 'GROUPS_PLUS_KNOCKOUT';
           const scopedGroups = ageGroupId
             ? groups.filter((g) => {
                 const firstTeam = g.teamDetails?.[0];
@@ -775,7 +775,8 @@ export default function TournamentDetailPage() {
                   tournamentId={tournament.id}
                   isOrganizer={true}
                   ageGroupId={ageGroupId}
-                  isRegistrationOpen={!tournament.isRegistrationClosed}
+                  isRegistrationOpen={!ageGroup?.isRegistrationClosed}
+                  drawCompleted={ageGroup?.drawCompleted}
                   matchPeriodType={ageGroup?.matchPeriodType}
                   halfDurationMinutes={ageGroup?.halfDurationMinutes}
                   halfTimePauseMinutes={ageGroup?.halfTimePauseMinutes}

--- a/src/app/main/tournaments/[id]/page.tsx
+++ b/src/app/main/tournaments/[id]/page.tsx
@@ -908,6 +908,8 @@ export default function TournamentDetailPage() {
             tournamentId={tournament.id}
             isOrganizer={false}
             ageGroupId={ageGroup?.id}
+            isRegistrationOpen={!ageGroup?.isRegistrationClosed}
+            drawCompleted={ageGroup?.drawCompleted}
             matchPeriodType={ageGroup?.matchPeriodType}
             halfDurationMinutes={ageGroup?.halfDurationMinutes}
             halfTimePauseMinutes={ageGroup?.halfTimePauseMinutes}


### PR DESCRIPTION
- Fix Generate Bracket button staying disabled after groups/draw are done.
- Pass ageGroup.isRegistrationClosed instead of tournament.isRegistrationClosed.
- Pass drawCompleted from ageGroup so GROUPS_PLUS_KNOCKOUT gating works.
- Remove LEAGUE from needsGroups check (no pot draw required for League).

Refs #0